### PR TITLE
fix-VolumeFromTriangles-VolumeFromTetrahedrons-Update-Not-Called

### DIFF
--- a/component/engine/VolumeFromTetrahedrons.inl
+++ b/component/engine/VolumeFromTetrahedrons.inl
@@ -58,8 +58,10 @@ VolumeFromTetrahedrons<DataTypes>::VolumeFromTetrahedrons()
     , d_tetras(initData(&d_tetras,"tetras","If not set by user, find the context topology"))
     , d_hexas(initData(&d_hexas,"hexas","If not set by user, find the context topology"))
     , d_volume(initData(&d_volume,Real(0.0),"volume",""))
-    , d_doUpdate(initData(&d_doUpdate,false,"update","If true, will update the volume at each time step"))
+    , d_doUpdate(initData(&d_doUpdate,true,"update","If true, will update the volume at each time step"))//Set at true by default, otherwise the volume is not computed
 {
+    f_printLog.setValue(true);
+    this->f_listening.setValue(true); //To wait for the events, otherwise the function update will never be called
     d_volume.setReadOnly(true);
     setDirtyValue();
 }

--- a/component/engine/VolumeFromTriangles.inl
+++ b/component/engine/VolumeFromTriangles.inl
@@ -57,10 +57,11 @@ VolumeFromTriangles<DataTypes>::VolumeFromTriangles()
     , d_triangles(initData(&d_triangles,"triangles","If not set by user, find the context topology"))
     , d_quads(initData(&d_quads,"quads","If not set by user, find the context topology"))
     , d_volume(initData(&d_volume,Real(0.0),"volume","Relevant if closed surface"))
-    , d_doUpdate(initData(&d_doUpdate,false,"update","If true, will update the volume at each time step"))
+    , d_doUpdate(initData(&d_doUpdate,true,"update","If true, will update the volume at each time step")) //Set at true by default, otherwise the volume is not computed
 {
     d_volume.setReadOnly(true);
     setDirtyValue();
+    this->f_listening.setValue(true); //To wait for the events, otherwise the function update will never be called
 }
 
 


### PR DESCRIPTION
Patch for the VolumeFromTriangles.inl and VolumeFromTetrahedrons.inl files.

NB: YOU CAN IGNORE THIS PATCH IF the fact that the **engines computed the volume only at the initialization of the graph** and when the reinit function is called

Fix the fact that VolumeFromTriangles and VolumeFromTetrahedrons engines did not call the updateVolume function. 
The problem came from the fact that the engines had the attributes f_listening and d_doUpdate were set to false.
The patch can be tested using examples/ component/engine/VolumeFromTriangles/Finger.pyscn (the scene examples/ component/engine/VolumeFromTetrahedrons/Finger.pyscn does not permit the test because the object is not fixed -> moves instead of being  deformed)