### PR TITLE
[constraint] Add SOFA macro to create dll link

### DIFF
--- a/component/constraint/model/CableModel.h
+++ b/component/constraint/model/CableModel.h
@@ -63,7 +63,7 @@ using sofa::core::VecCoordId ;
  * This class contains common implementation of cable constraints
 */
 template< class DataTypes >
-class CableModel : virtual public SoftRobotsConstraint<DataTypes>
+class SOFA_SOFTROBOTS_API CableModel : virtual public SoftRobotsConstraint<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(CableModel,DataTypes),

--- a/component/constraint/model/SurfacePressureModel.h
+++ b/component/constraint/model/SurfacePressureModel.h
@@ -62,7 +62,7 @@ using sofa::core::VecCoordId ;
  * This class contains common implementation of surface pressure constraints
 */
 template< class DataTypes >
-class SurfacePressureModel : virtual public SoftRobotsConstraint<DataTypes>
+class SOFA_SOFTROBOTS_API SurfacePressureModel : virtual public SoftRobotsConstraint<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(SurfacePressureModel,DataTypes),


### PR DESCRIPTION
This PR fix an issue that appear when you try to use the SOFA SoftRobots plugin with the private SOFA plugin SoftRobots.Inverse.

The problem occur particularly when you compile both on windows : 
errors appear about missing links from SoftRobots.Inverse of the SoftRobots class "SurfacePressureModel" and "CableModel.

By adding the SOFA macro "SOFA_SOFTROBOTS_API" for both class the problem should be resolved.

I also note that this macro is missing for other class of SoftRobots, is it by choice ?

Thanks in advance