### PR TITLE
[SoftRobots] FIX compilation problem with #include<GL/glut.h>

### DIFF
--- a/component/controller/AnimationEditor.inl
+++ b/component/controller/AnimationEditor.inl
@@ -34,7 +34,6 @@
 
 #ifdef SOFA_WITH_OPENGL
 #include <sofa/helper/gl/template.h>
-#include <sofa/helper/system/glut.h>
 using sofa::helper::gl::glVertexT;
 #endif
 


### PR DESCRIPTION
Well current SoftRobots version does not compile against recent sofa. 