### PR TITLE
[component] added component state management to prevent segfault

### DIFF
--- a/component/constraint/CableConstraint.h
+++ b/component/constraint/CableConstraint.h
@@ -148,7 +148,7 @@ public:
     using CableModel<DataTypes>::d_maxDispVariation ;
     using CableModel<DataTypes>::d_force ;
     using CableModel<DataTypes>::d_displacement ;
-//    using CableModel<DataTypes>::m_componentstate ;
+    using CableModel<DataTypes>::m_componentstate ;
     ///////////////////////////////////////////////////////////////////////////
 
 protected:

--- a/component/constraint/CableConstraint.h
+++ b/component/constraint/CableConstraint.h
@@ -148,6 +148,7 @@ public:
     using CableModel<DataTypes>::d_maxDispVariation ;
     using CableModel<DataTypes>::d_force ;
     using CableModel<DataTypes>::d_displacement ;
+//    using CableModel<DataTypes>::m_componentstate ;
     ///////////////////////////////////////////////////////////////////////////
 
 protected:

--- a/component/constraint/CableConstraint.inl
+++ b/component/constraint/CableConstraint.inl
@@ -130,8 +130,8 @@ void CableConstraint<DataTypes>::getConstraintResolution(const ConstraintParams*
                                                          std::vector<ConstraintResolution*>& resTab,
                                                          unsigned int& offset)
 {
-//    if(this->m_componentstate != ComponentState::Valid)
-//            return ;
+    if(m_componentstate != ComponentState::Valid)
+            return ;
 
     SOFA_UNUSED(cParam);
 

--- a/component/constraint/CableConstraint.inl
+++ b/component/constraint/CableConstraint.inl
@@ -44,6 +44,7 @@ namespace component
 namespace constraintset
 {
 
+using sofa::core::objectmodel::ComponentState;
 using sofa::helper::WriteAccessor;
 
 template<class DataTypes>
@@ -110,16 +111,18 @@ void CableConstraint<DataTypes>::reinit()
 template<class DataTypes>
 void CableConstraint<DataTypes>::internalInit()
 {
-    // check for errors in the initialization
     if(d_value.getValue().size()==0)
     {
-        WriteAccessor<Data<vector<Real>>> inputValue = d_value;
-        inputValue.resize(1,0.);
+        WriteAccessor<Data<vector<Real>>> value = d_value;
+        value.resize(1,0.);
     }
 
+    // check for errors in the initialization
     if(d_value.getValue().size()<d_valueIndex.getValue())
-        serr<<"bad size of inputValue ="<< d_value.getValue().size()<<"  or wrong value for inputIndex = "<<d_valueIndex.getValue()<<sendl;
-
+    {
+        msg_warning() << "Bad size for data value (size="<< d_value.getValue().size()<<"), or wrong value for data valueIndex (valueIndex="<<d_valueIndex.getValue()<<"). Set default valueIndex=0.";
+        d_valueIndex.setValue(0);
+    }
 }
 
 template<class DataTypes>
@@ -127,6 +130,9 @@ void CableConstraint<DataTypes>::getConstraintResolution(const ConstraintParams*
                                                          std::vector<ConstraintResolution*>& resTab,
                                                          unsigned int& offset)
 {
+//    if(this->m_componentstate != ComponentState::Valid)
+//            return ;
+
     SOFA_UNUSED(cParam);
 
     double imposed_value=d_value.getValue()[d_valueIndex.getValue()];

--- a/component/constraint/PartialRigidificationConstraint.inl
+++ b/component/constraint/PartialRigidificationConstraint.inl
@@ -88,58 +88,40 @@ void PartialRigidificationConstraint<DataTypes>::buildConstraintMatrix(const Con
 {
     SOFA_UNUSED(cParams);
 
-    std::cout<<"step0"<<std::endl;
     const VecCoord X = x.getValue();
     MatrixDeriv& matrix = *cMatrix.beginEdit();
     m_cid = cIndex;
-    std::cout<<"step1"<<std::endl;
     const Vec3 cx(1, 0, 0), cy(0, 1, 0), cz(0, 0, 1), vZero(0, 0, 0);
-  //  const Vec3 p0p1 = X[1].getCenter() - X[0].getCenter();
-
-//	const Deriv::Rot tau0p1cx = p0p1.cross(-cx);
-//	const Deriv::Rot tau0p1cy = p0p1.cross(-cy);
-//	const Deriv::Rot tau0p1cz = p0p1.cross(-cz);
-
-    std::cout<<"step2"<<std::endl;
 
     MatrixDerivRowIterator cit = matrix.writeLine(cIndex);
     cit.addCol(0, Deriv(cx, vZero));
-//	cit.addCol(0, Deriv(cx, tau0p1cx));
 
     cit = matrix.writeLine(cIndex+1);
     cit.setCol(0, Deriv(cy, vZero));
-//	cit.addCol(0, Deriv(cy, tau0p1cy));
 
     cit = matrix.writeLine(cIndex+2);
     cit.setCol(0, Deriv(cz, vZero));
-//	cit.addCol(0, Deriv(cz, tau0p1cz));
 
     cit = matrix.writeLine(cIndex+3);
     cit.setCol(0, Deriv(vZero, cx));
-//    cit.addCol(0, Deriv(cx.cross(p0p1), vZero));
 
     cit = matrix.writeLine(cIndex+4);
     cit.setCol(0, Deriv(vZero, cy));
-//    cit.addCol(0, Deriv(cy.cross(p0p1), vZero));
 
     cit = matrix.writeLine(cIndex+5);
     cit.setCol(0, Deriv(vZero, cz));
-//    cit.addCol(0, Deriv(cz.cross(p0p1), vZero));
 
-      std::cout<<"DEBUG/// state"<<mstate->getName()<<std::endl;
-
-      // Indicates the size of the constraint block
-      cIndex +=6;
+    // Indicates the size of the constraint block
+    cIndex +=6;
 }
 
 template<class DataTypes>
 void PartialRigidificationConstraint<DataTypes>::getConstraintResolution(std::vector<ConstraintResolution*>& resTab,
                                                                          unsigned int& offset)
 {
-//	for(size_t i = 0 ; i < 6 ; ++i)
     resTab[offset] = new PartialRigidificationConstraintResolution6Dof();
 
-    // indicates the size of the block on which the constraint resoluation works
+    // Indicates the size of the block on which the constraint resoluation works
     offset += 6;
 }
 

--- a/component/constraint/SurfacePressureConstraint.h
+++ b/component/constraint/SurfacePressureConstraint.h
@@ -149,6 +149,7 @@ protected:
     using SurfacePressureModel<DataTypes>::m_displayedValue ;
     using SurfacePressureModel<DataTypes>::m_columnId;
     using SurfacePressureModel<DataTypes>::m_visualization;
+//    using SoftRobotsConstraint<DataTypes>::m_componentstate;
     ////////////////////////////////////////////////////////////////////////////
 
 private:

--- a/component/constraint/SurfacePressureConstraint.h
+++ b/component/constraint/SurfacePressureConstraint.h
@@ -149,7 +149,7 @@ protected:
     using SurfacePressureModel<DataTypes>::m_displayedValue ;
     using SurfacePressureModel<DataTypes>::m_columnId;
     using SurfacePressureModel<DataTypes>::m_visualization;
-//    using SoftRobotsConstraint<DataTypes>::m_componentstate;
+    using SoftRobotsConstraint<DataTypes>::m_componentstate;
     ////////////////////////////////////////////////////////////////////////////
 
 private:

--- a/component/constraint/SurfacePressureConstraint.inl
+++ b/component/constraint/SurfacePressureConstraint.inl
@@ -144,15 +144,18 @@ void SurfacePressureConstraint<DataTypes>::reset()
 template<class DataTypes>
 void SurfacePressureConstraint<DataTypes>::initData()
 {
-    // check for errors in the initialization
     if(d_value.getValue().size()==0)
     {
-        WriteAccessor<Data<vector<Real>>> inputValue = d_value;
-        inputValue.resize(1,0.);
+        WriteAccessor<Data<vector<Real>>> value = d_value;
+        value.resize(1,0.);
     }
 
+    // check for errors in the initialization
     if(d_value.getValue().size()<d_valueIndex.getValue())
-        msg_error(this) <<"bad size of inputValue ="<< d_value.getValue().size()<<"  or wrong value for inputIndex = "<<d_valueIndex.getValue();
+    {
+        msg_warning() <<"Bad size for data value (size="<< d_value.getValue().size()<<"), or wrong value for data valueIndex (valueIndex="<<d_valueIndex.getValue()<<"). Set default valueIndex=0.";
+        d_valueIndex.setValue(0);
+    }
     else
         m_displayedValue = d_value.getValue()[d_valueIndex.getValue()];
 }
@@ -162,6 +165,9 @@ template<class DataTypes>
 void SurfacePressureConstraint<DataTypes>::getConstraintResolution(std::vector<ConstraintResolution*>& resTab,
                                                                    unsigned int& offset)
 {
+//    if(m_componentstate != ComponentState::Valid)
+//            return ;
+
     double imposed_value = d_value.getValue()[d_valueIndex.getValue()];
     m_displayedValue = d_value.getValue()[d_valueIndex.getValue()];
 

--- a/component/constraint/SurfacePressureConstraint.inl
+++ b/component/constraint/SurfacePressureConstraint.inl
@@ -47,6 +47,7 @@ namespace constraintset
 namespace _surfacepressureconstraint_
 {
 
+using sofa::core::objectmodel::ComponentState ;
 using sofa::helper::WriteAccessor ;
 using sofa::defaulttype::Vec3d;
 using sofa::helper::vector ;
@@ -165,8 +166,8 @@ template<class DataTypes>
 void SurfacePressureConstraint<DataTypes>::getConstraintResolution(std::vector<ConstraintResolution*>& resTab,
                                                                    unsigned int& offset)
 {
-//    if(m_componentstate != ComponentState::Valid)
-//            return ;
+    if(m_componentstate != ComponentState::Valid)
+            return ;
 
     double imposed_value = d_value.getValue()[d_valueIndex.getValue()];
     m_displayedValue = d_value.getValue()[d_valueIndex.getValue()];

--- a/component/constraint/UnilateralPlaneConstraint.h
+++ b/component/constraint/UnilateralPlaneConstraint.h
@@ -145,6 +145,7 @@ private:
     /// otherwise any access to the base::attribute would require
     /// the "this->" approach.
     using Constraint<DataTypes>::mstate ;
+    using Constraint<DataTypes>::m_componentstate ;
     ////////////////////////////////////////////////////////////////////////////
 };
 

--- a/component/constraint/UnilateralPlaneConstraint.inl
+++ b/component/constraint/UnilateralPlaneConstraint.inl
@@ -46,6 +46,7 @@ namespace component
 namespace constraintset
 {
 
+using sofa::core::objectmodel::ComponentState;
 using sofa::core::VecCoordId;
 using sofa::core::ConstVecCoordId ;
 using sofa::helper::WriteAccessor ;
@@ -91,20 +92,28 @@ UnilateralPlaneConstraint<DataTypes>::~UnilateralPlaneConstraint()
 template<class DataTypes>
 void UnilateralPlaneConstraint<DataTypes>::init()
 {
+    m_componentstate = ComponentState::Invalid;
     Inherit::init();
 
     if(mstate == nullptr)
-        msg_error(this) << "There is no mechanical state associated with this node. "
+    {
+        msg_error(this) << "There is no mechanical state associated with this node. Component deactivated."
                            "To remove this error message, fix your scene possibly by "
                            "adding a MechanicalObject." ;
+        return;
+    }
 
     checkIndicesRegardingState();
+    m_componentstate = ComponentState::Valid;
 }
 
 
 template<class DataTypes>
 void UnilateralPlaneConstraint<DataTypes>::reinit()
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
+
     checkIndicesRegardingState();
 }
 
@@ -130,6 +139,9 @@ void UnilateralPlaneConstraint<DataTypes>::buildConstraintMatrix(const core::Con
                                                                   unsigned int &cIndex,
                                                                  const DataVecCoord &x)
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
+
     SOFA_UNUSED(cParams);
     SOFA_UNUSED(x);
 
@@ -164,6 +176,9 @@ void UnilateralPlaneConstraint<DataTypes>::getConstraintViolation(const core::Co
                                                                    const DataVecCoord &xfree,
                                                                    const DataVecDeriv &vfree)
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
+
     SOFA_UNUSED(cParams);
     SOFA_UNUSED(vfree);
 
@@ -187,6 +202,9 @@ void UnilateralPlaneConstraint<DataTypes>::getConstraintResolution(const Constra
                                                                    std::vector<core::behavior::ConstraintResolution*>& resTab,
                                                                    unsigned int& offset)
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
+
     SOFA_UNUSED(cParams);
 
     resTab[offset] = new UnilateralPlaneConstraintResolution(1);
@@ -197,6 +215,8 @@ void UnilateralPlaneConstraint<DataTypes>::getConstraintResolution(const Constra
 template<class DataTypes>
 void UnilateralPlaneConstraint<DataTypes>::draw(const VisualParams* vparams)
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
 
     if (!vparams->displayFlags().getShowCollisionModels())
         return;

--- a/component/constraint/model/CableModel.h
+++ b/component/constraint/model/CableModel.h
@@ -135,16 +135,6 @@ protected:
 
     SReal getCableLength(const VecCoord &positions);
 
-private:
-    void internalInit();
-
-    void checkIndicesRegardingState();
-    void initActuatedPoints();
-
-    void drawPullPoint(const VisualParams* vparams);
-    void drawPoints(const VisualParams* vparams);
-    void drawLinesBetweenPoints(const VisualParams* vparams);
-
     ////////////////////////// Inherited attributes ////////////////////////////
     /// https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
     /// Bring m_state in the current lookup context.
@@ -159,6 +149,16 @@ private:
     using SoftRobotsConstraint<DataTypes>::addAlias ;
     using SoftRobotsConstraint<DataTypes>::m_componentstate ;
     ////////////////////////////////////////////////////////////////////////////
+
+private:
+    void internalInit();
+
+    void checkIndicesRegardingState();
+    void initActuatedPoints();
+
+    void drawPullPoint(const VisualParams* vparams);
+    void drawPoints(const VisualParams* vparams);
+    void drawLinesBetweenPoints(const VisualParams* vparams);
 };
 
 // Declares template as extern to avoid the code generation of the template for

--- a/component/constraint/model/CableModel.h
+++ b/component/constraint/model/CableModel.h
@@ -157,6 +157,7 @@ private:
     using SoftRobotsConstraint<DataTypes>::m_deltaMax ;
     using SoftRobotsConstraint<DataTypes>::m_lambdaMax ;
     using SoftRobotsConstraint<DataTypes>::addAlias ;
+    using SoftRobotsConstraint<DataTypes>::m_componentstate ;
     ////////////////////////////////////////////////////////////////////////////
 };
 

--- a/component/constraint/model/SurfacePressureModel.h
+++ b/component/constraint/model/SurfacePressureModel.h
@@ -148,6 +148,7 @@ private:
     using SoftRobotsConstraint<DataTypes>::m_state ;
     using SoftRobotsConstraint<DataTypes>::getContext ;
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
+    using SoftRobotsConstraint<DataTypes>::m_componentstate ;
     ////////////////////////////////////////////////////////////////////////////
 };
 

--- a/component/constraint/model/SurfacePressureModel.h
+++ b/component/constraint/model/SurfacePressureModel.h
@@ -135,11 +135,6 @@ protected:
     void drawLines(const VisualParams* vparams, float red, float green, float blue);
     std::string getValueString(Real pressure);
 
-private:
-
-    void drawValue(const core::visual::VisualParams* vparams);
-    void computeEdges();
-
     ////////////////////////// Inherited attributes ////////////////////////////
     /// https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
     /// Bring m_state in the current lookup context.
@@ -150,6 +145,11 @@ private:
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
     using SoftRobotsConstraint<DataTypes>::m_componentstate ;
     ////////////////////////////////////////////////////////////////////////////
+
+private:
+
+    void drawValue(const core::visual::VisualParams* vparams);
+    void computeEdges();
 };
 
 // Declares template as extern to avoid the code generation of the template for

--- a/component/constraint/model/SurfacePressureModel.inl
+++ b/component/constraint/model/SurfacePressureModel.inl
@@ -305,8 +305,8 @@ void SurfacePressureModel<DataTypes>::buildConstraintMatrix(const ConstraintPara
                                                                unsigned int &columnIndex,
                                                                const DataVecCoord &x)
 {
-//    if(m_componentstate != ComponentState::Valid)
-//            return ;
+    if(m_componentstate != ComponentState::Valid)
+            return ;
 
     SOFA_UNUSED(cParams);
 

--- a/component/controller/AnimationEditor.inl
+++ b/component/controller/AnimationEditor.inl
@@ -64,6 +64,8 @@ namespace controller
 namespace _animationeditor_
 {
 
+using sofa::core::objectmodel::ComponentState;
+
 using sofa::core::objectmodel::KeypressedEvent;
 using sofa::simulation::AnimateBeginEvent;
 
@@ -115,6 +117,8 @@ AnimationEditor<DataTypes>::~AnimationEditor()
 template<class DataTypes>
 void AnimationEditor<DataTypes>::init()
 {
+    m_componentstate = ComponentState::Invalid;
+
     m_keyFramesID.clear();
 
     if(d_maxKeyFrame.getValue()<=0)
@@ -123,23 +127,26 @@ void AnimationEditor<DataTypes>::init()
     m_state = dynamic_cast<MechanicalState<DataTypes>*>(getContext()->getMechanicalState());
     if(m_state == nullptr)
     {
-        msg_warning() <<"This component needs a mechanical state in its context with the correct template. Abort.";
+        msg_error() <<"This component needs a mechanical state in its context with the correct template. Abort.";
         return;
     }
-    else //Store initial state
-    {
-        m_keyFramesID.push_back(0);
-        m_animation.resize(1,m_state->read(core::ConstVecCoordId::position())->getValue());
-    }
+
+    m_keyFramesID.push_back(0);
+    m_animation.resize(1,m_state->read(core::ConstVecCoordId::position())->getValue());
 
     if(d_load.getValue())
         loadAnimation();
+
+    m_componentstate = ComponentState::Valid;
 }
 
 
 template<class DataTypes>
 void AnimationEditor<DataTypes>::reinit()
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
+
     if(d_maxKeyFrame.getValue()<=0)
         d_maxKeyFrame.setValue(1);
 
@@ -164,6 +171,9 @@ void AnimationEditor<DataTypes>::bwdInit(){}
 template<class DataTypes>
 void AnimationEditor<DataTypes>::reset()
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
+
     d_cursor.setValue(0);
     m_isFrameDirty = true;
     m_time = 0.;
@@ -174,12 +184,6 @@ void AnimationEditor<DataTypes>::reset()
 template<class DataTypes>
 void AnimationEditor<DataTypes>::loadAnimation()
 {
-    if(m_state == nullptr)
-    {
-        msg_warning() <<"Failed to fetch a mechanical state, abort.";
-        return;
-    }
-
     ifstream file;
     file.open(d_filename.getValue(), ifstream::in);
     if (file.is_open())
@@ -267,12 +271,6 @@ void AnimationEditor<DataTypes>::loadAnimation()
 template<class DataTypes>
 void AnimationEditor<DataTypes>::saveAnimation()
 {
-    if(m_state == nullptr)
-    {
-        msg_warning() <<"Failed to fetch a mechanical state, abort.";
-        return;
-    }
-
     msg_info() <<"Saved animation of "<<m_animation.size()<<" frames in "<<d_filename.getValue();
     ofstream file;
     file.open(d_filename.getValue());
@@ -306,11 +304,8 @@ void AnimationEditor<DataTypes>::saveAnimation()
 template<class DataTypes>
 void AnimationEditor<DataTypes>::onBeginAnimationStep(const double dt)
 {
-    if(m_state == nullptr)
-    {
-        msg_warning() <<"Failed to fetch a mechanical state, abort.";
-        return;
-    }
+    if(m_componentstate != ComponentState::Valid)
+            return ;
 
     if(d_dx.isSet())
     {
@@ -356,6 +351,9 @@ void AnimationEditor<DataTypes>::onEndAnimationStep(const double dt)
 template<class DataTypes>
 void AnimationEditor<DataTypes>::handleEvent(Event *event)
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
+
     if(!d_dx.isSet())
     {
         if (KeypressedEvent* keyEvent = dynamic_cast<KeypressedEvent*>(event))
@@ -747,6 +745,9 @@ void AnimationEditor<DataTypes>::updateAnimationWithInterpolation(const int star
 template<class DataTypes>
 void AnimationEditor<DataTypes>::draw(const VisualParams* vparams)
 {
+    if(m_componentstate != ComponentState::Valid)
+            return ;
+
     if(!d_drawTimeline.getValue()) return;
 
 #ifdef SOFA_WITH_DACCORD
@@ -758,27 +759,6 @@ void AnimationEditor<DataTypes>::draw(const VisualParams* vparams)
 #ifdef SOFA_WITH_OPENGL
     glDisable(GL_LIGHTING);
     int ratio = round(vparams->viewport()[2]/d_maxKeyFrame.getValue());
-
-
-    //////////////////////////////VALUES/////////////////////////////
-//    string min = "0";
-//    string max = std::to_string(d_maxKeyFrame.getValue());
-//    string cursor = std::to_string(d_cursor.getValue());
-//    const char* value= min.c_str();
-//    vparams->drawTool()->writeOverlayText(ratio-1,vparams->viewport()[3]/12*11+5 //Coordinate
-//            ,10                                                                  //Size
-//            ,Vec4f(0.6,0.6,0.6,1.)                                               //Color
-//            ,min.c_str());                                                       //Text
-//    vparams->drawTool()->writeOverlayText(d_maxKeyFrame.getValue()*ratio,vparams->viewport()[3]/12*11+5
-//            ,10
-//            ,Vec4f(0.6,0.,0.,1.)
-//            ,max.c_str());
-//    vparams->drawTool()->writeOverlayText(d_cursor.getValue()*ratio+10,vparams->viewport()[3]/10*9-25
-//            ,10
-//            ,Vec4f(0.8,0.8,0.8,1.)
-//            ,cursor.c_str());
-    ///////////////////////////////////////////////////////////////////
-
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();

--- a/component/controller/CommunicationController.inl
+++ b/component/controller/CommunicationController.inl
@@ -255,7 +255,7 @@ template<class DataTypes>
 void CommunicationController<DataTypes>::checkDataSize(const unsigned int& nbDataFieldReceived)
 {
     if(nbDataFieldReceived!=d_nbDataField.getValue())
-        msg_warning(this) << "Something wrong with the size of data received. Please check template.";
+        msg_warning() << "Something wrong with the size of data received. Please check template.";
 }
 
 
@@ -274,7 +274,7 @@ void CommunicationController<DataTypes>::sendData()
 
     bool status = m_socket->send(message);
     if(!status)
-        msg_warning(this) << "Problem with communication";
+        msg_warning() << "Problem with communication";
 }
 
 
@@ -308,7 +308,7 @@ void CommunicationController<DataTypes>::receiveData()
         checkDataSize(nbDataFieldReceived);
     }
     else
-        msg_warning(this) << "Problem with communication";
+        msg_warning() << "Problem with communication";
 }
 
 

--- a/component/controller/DataVariationLimiter.inl
+++ b/component/controller/DataVariationLimiter.inl
@@ -82,7 +82,7 @@ void DataVariationLimiter<DataTypes>::initData()
 {
     //Init data
     if(!d_input.isSet())
-        msg_warning(this) << "Input not set.";
+        msg_warning() << "Input not set.";
     else
     {
         d_inputSize.setValue(d_input.getValue().size());
@@ -152,7 +152,7 @@ void DataVariationLimiter<DataTypes>::onBeginAnimationStep(const double dt)
 
     if(input.size()<d_inputSize.getValue())
     {
-        msg_warning(this) << "Problem with input size. Abort.";
+        msg_warning() << "Problem with input size. Abort.";
         return;
     }
 
@@ -179,7 +179,7 @@ void DataVariationLimiter<DataTypes>::interpolate(const int index)
 
     if(d_inputSize.getValue() != output.size() || d_inputSize.getValue() != m_step.size() || d_inputSize.getValue() != m_isStabilizing.size())
     {
-        dmsg_warning(this) << "Size problem in interpolate(), size="<<d_inputSize.getValue() << ", output.size=" <<output.size() << ", step.size=" <<m_step.size() << ", isStab.size=" <<m_isStabilizing.size() << ". Abort.";
+        dmsg_warning() << "Size problem in interpolate(), size="<<d_inputSize.getValue() << ", output.size=" <<output.size() << ", step.size=" <<m_step.size() << ", isStab.size=" <<m_isStabilizing.size() << ". Abort.";
         return;
     }
 

--- a/component/controller/SerialPortBridgeGeneric.cpp
+++ b/component/controller/SerialPortBridgeGeneric.cpp
@@ -95,14 +95,9 @@ void SerialPortBridgeGeneric::init()
         m_packetOut[i] = (unsigned char)0;
     if (d_redundancy.getValue()<1)
     {
-        msg_warning(this) <<"No valid number of packets set in Redundancy, set automatically to 1";
+        msg_warning() <<"No valid number of packets set in Redundancy, set automatically to 1";
         d_redundancy.setValue(1);
     }
-
-    // Vector to void*
-    //void* packetPtr = new unsigned char[m_packetOut.size() * sizeof(m_packetOut)];
-    //memcpy (packetPtr, m_packetOut.data(), m_packetOut.size() * sizeof(m_packetOut));
-    //TODO : the two previous lines were currently useless -> Finish implementation using them or remove them definitely
 }
 
 
@@ -111,9 +106,9 @@ void SerialPortBridgeGeneric::checkConnection()
     int status = m_serial.Open(d_port.getValue().c_str() , d_baudRate.getValue());
 
     if (status!=1)
-        msg_warning(this) <<"No serial port found";
+        msg_warning() <<"No serial port found";
     else
-        msg_info(this) <<"Serial port found";
+        msg_info() <<"Serial port found";
 }
 
 
@@ -151,7 +146,7 @@ void SerialPortBridgeGeneric::sendPacketPrecise()
     int packetlength=d_size.getValue();
     m_packetOut.resize(packetlength*2+1);
 
-    m_packetOut[0] = (unsigned char)245;        //first half
+    m_packetOut[0] = (unsigned char)245; //first half
     for (int i=0; i<packetlength; i++)
     {
         int value = d_packetOut.getValue()[i]*1000; //conversion from meter to millimeter
@@ -219,11 +214,11 @@ void SerialPortBridgeGeneric::receivePacket()
 void SerialPortBridgeGeneric::checkData()
 {
     if(!d_size.isSet())
-        msg_warning(this) <<"Size not set.";
+        msg_warning() <<"Size not set.";
 
     if((int)d_packetOut.getValue().size()!=d_size.getValue())
     {
-        msg_warning(this) <<"The user specified a size for sentData, size="<<d_size.getValue()
+        msg_warning() <<"The user specified a size for sentData, size="<<d_size.getValue()
                           <<" but sentData.size="<<d_packetOut.getValue().size()<<"."
                           <<" To remove this warning you can either change the value of 'size' or 'sentData'."
                           <<" Make sure it corresponds to what the arduino card is expecting.";

--- a/component/forcefield/PREquivalentStiffnessForceField.h
+++ b/component/forcefield/PREquivalentStiffnessForceField.h
@@ -144,6 +144,7 @@ private :
     /// otherwise any access to the base::attribute would require
     /// the "this->" approach.
     using ForceField<DataTypes>::getContext ;
+    using ForceField<DataTypes>::m_componentstate;
     ////////////////////////////////////////////////////////////////////////////
 };
 

--- a/component/forcefield/PartialRigidificationForceField.inl
+++ b/component/forcefield/PartialRigidificationForceField.inl
@@ -72,11 +72,6 @@ template<class DataTypes1, class DataTypes2>
 void PartialRigidificationForceField<DataTypes1, DataTypes2>::addKToMatrix(const MechanicalParams* mparams,
                                                                            const MultiMatrixAccessor* matrix)
 {
-
-    if(f_printLog.getValue())
-        sout << "entering addKToMatrix" << sendl;
-
-
     MultiMatrixAccessor::MatrixRef mat11 = matrix->getMatrix(mstate1);
     MultiMatrixAccessor::MatrixRef mat22 = matrix->getMatrix(mstate2);
     MultiMatrixAccessor::InteractionMatrixRef mat12 = matrix->getMatrix(mstate1, mstate2);
@@ -85,18 +80,11 @@ void PartialRigidificationForceField<DataTypes1, DataTypes2>::addKToMatrix(const
     const helper::vector<BaseMatrix*>* J0J1 = d_subsetMultiMapping.get()->getJs();
 
     if(J0J1 == NULL)
-        serr<<" WARNING J0J1 null";
-    else
-    {
-        std::cout<<" J0J1 ok"<<std::endl;
-        std::cout<<" J0 = "<<std::endl;
-        std::cout<<(*J0J1)[0] <<std::endl;
-    }
-
+        dmsg_warning()<<"J0J1 null";
 
     if (J0J1->size() != 2)
     {
-        serr << "subsetMultiMapping doesn't have 2 output mechanical states. This is not handled in PartialRigidification. AddKToMatrix not computed " << sendl;
+        msg_error() << "SubsetMultiMapping does not have two output mechanical states. This is not handled in PartialRigidification. AddKToMatrix not computed.";
         return;
     }
     CompressedRowSparseMatrix<_3_3_Matrix_Type>* J0;
@@ -110,16 +98,16 @@ void PartialRigidificationForceField<DataTypes1, DataTypes2>::addKToMatrix(const
     Jr = dynamic_cast<const CompressedRowSparseMatrix<_3_6_Matrix_Type> *> (d_rigidMapping.get()->getJ() );
 
     if(J0 == NULL) {
-        serr << "J0 null" << sendl;
+        dmsg_error() << "J0 null";
     }
     if(J1 == NULL) {
-        serr << "J1 null" << sendl;
+        dmsg_error() << "J1 null";
     }
     if(Jr == NULL) {
-        serr << "Jr null" << sendl;
+        dmsg_error() << "Jr null";
     }
     if((J0 == NULL) || (J1 == NULL)  || (Jr == NULL) ) {
-        serr << "a jacobian matrix from Mapping is missing. AddKToMatrix not computed" << sendl;
+        msg_error() << "A jacobian matrix from Mapping is missing. AddKToMatrix not computed";
         return;
     }
 
@@ -236,10 +224,6 @@ void PartialRigidificationForceField<DataTypes1, DataTypes2>::addKToMatrix(const
     delete K;
     delete mappedFFMatrix;
     delete mappedFFMatrixAccessor;
-
-    if(f_printLog.getValue())
-        sout << "exit addKToMatrix" << sendl;
-
 }
 
 template<class DataTypes1, class DataTypes2>
@@ -264,21 +248,6 @@ void PartialRigidificationForceField<DataTypes1, DataTypes2>::testBuildJacobian(
     //--
 
     d_mappedForceField.get()->addKToMatrix(mparams, mappedFFMatrixAccessor);
-
-    // CompressedRowSparseMatrix<_3_6_Matrix_Type> J1Jr ;
-    // CompressedRowSparseMatrix<_3_3_Matrix_Type> J0tK ;
-    // CompressedRowSparseMatrix<_3_3_Matrix_Type> J0tKJ0 ;
-    // CompressedRowSparseMatrix<_3_6_Matrix_Type> J0tKJ1Jr ;
-    // CompressedRowSparseMatrix<_6_6_Matrix_Type> JrtJ1tKJ1Jr ;
-    // CompressedRowSparseMatrix<_6_3_Matrix_Type> JrtJ1tK ;
-    // CompressedRowSparseMatrix<_6_3_Matrix_Type> JrtJ1tKJ0 ;
-
-    //--Warning K set but unused : TODO clean or refactorize
-
-    //CompressedRowSparseMatrix<_3_3_Matrix_Type>* K ;
-    //K = dynamic_cast<CompressedRowSparseMatrix<_3_3_Matrix_Type>*>(r.matrix);
-
-    //--
 
     sofa::core::State<DataTypes1> * state = dynamic_cast<sofa::core::State<DataTypes1> *>(mstate);
     unsigned int stateSize = mstate->getSize();

--- a/component/forcefield/PipeForceField.inl
+++ b/component/forcefield/PipeForceField.inl
@@ -44,8 +44,6 @@ using sofa::helper::WriteAccessor ;
 #include <string>
 using std::string ;
 
-
-
 #include <fstream>
 using std::filebuf ;
 
@@ -122,29 +120,39 @@ template<typename DataTypes>
 void PipeForceField<DataTypes>::addKToMatrix(const MechanicalParams* mparams,
                                                const MultiMatrixAccessor* matrix)
 {
-    sout << "Entering addKToMatrix" << sendl;
-
-
-    if (d_barycentricMapping.get() == NULL ) {serr << "Mapping is missing. AddKToMatrix not computed" << sendl; return;}
-    else                                      sout << "Got mapping" << sendl;
-    if (d_mappedForceField.get() == NULL )   {serr << "MappedFF is missing. AddKToMatrix not computed" << sendl; return;}
-    else                                      sout << "Got mappedFF" << sendl;
+    if (d_barycentricMapping.get() == NULL )
+    {
+        msg_error() << "Mapping is missing. AddKToMatrix not computed";
+        return;
+    }
+    if (d_mappedForceField.get() == NULL )
+    {
+        msg_error() << "MappedFF is missing. AddKToMatrix not computed";
+        return;
+    }
 
 
     //Get the jacobian matrix from the BarycentricMapping
     const CompressedRowSparseMatrix<_3_3_Matrix_Type>* J;
     J = dynamic_cast<const CompressedRowSparseMatrix<_3_3_Matrix_Type> *> (d_barycentricMapping.get()->getJ() );
 
-    if (J == NULL ) {serr << "Jacobian matrix from Mapping is missing. AddKToMatrix not computed" << sendl; return;}
-    else             sout << "Got Jacobian matrix from Mapping" << sendl;
+    if (J == NULL )
+    {
+        msg_error() << "Jacobian matrix from Mapping is missing. AddKToMatrix not computed";
+        return;
+    }
 
 
     //Get the stiffness matrix from the mapped ForceField
     CompressedRowSparseMatrix< _3_3_Matrix_Type >* mappedFFMatrix = new CompressedRowSparseMatrix< _3_3_Matrix_Type > ( );
     BaseMechanicalState* springState = d_mappedForceField.get()->getContext()->getMechanicalState();
 
-    if (springState == NULL ) {serr << "Mstate from mappedFF is missing. AddKToMatrix not computed" << sendl; delete mappedFFMatrix; return;}
-    else                 sout << "Got mstate matrix from mappedFF" << sendl;
+    if (springState == NULL )
+    {
+        msg_error() << "Mstate from mappedFF is missing. AddKToMatrix not computed";
+        delete mappedFFMatrix;
+        return;
+    }
 
     DefaultMultiMatrixAccessor* mappedFFMatrixAccessor = new DefaultMultiMatrixAccessor;
     mappedFFMatrixAccessor->addMechanicalState(springState);
@@ -185,8 +193,6 @@ void PipeForceField<DataTypes>::addKToMatrix(const MechanicalParams* mparams,
     delete K;
     delete mappedFFMatrix;
     delete mappedFFMatrixAccessor;
-
-    sout << "exit addKToMatrix" << sendl;
 }
 
 

--- a/tests/component/constraint/SurfacePressureConstraintTest.cpp
+++ b/tests/component/constraint/SurfacePressureConstraintTest.cpp
@@ -31,6 +31,8 @@
 #include <SofaTest/Sofa_test.h>
 
 #include "../../../component/constraint/SurfacePressureConstraint.h"
+using sofa::component::constraintset::SurfacePressureConstraint;
+
 #include <SofaBaseLinearSolver/FullVector.h>
 #include <sofa/helper/BackTrace.h>
 #include <sofa/helper/system/Locale.h>
@@ -49,15 +51,18 @@ using std::string;
 using std::fabs;
 using std::stof;
 
+using sofa::core::objectmodel::ComponentState;
+
 namespace sofa {
 
     template <typename _DataTypes>
-    struct SurfacePressureConstraintTest : public Sofa_test<typename _DataTypes::Real>, sofa::component::constraintset::SurfacePressureConstraint<_DataTypes>
+    struct SurfacePressureConstraintTest : public Sofa_test<typename _DataTypes::Real>, SurfacePressureConstraint<_DataTypes>
     {
+
+//        using SurfacePressureConstraint<_DataTypes>::m_componentstate;
 
         simulation::Node::SPtr m_root;                 ///< Root of the scene graph, created by the constructor an re-used in the tests
         simulation::Simulation* m_simulation;          ///< created by the constructor an re-used in the tests
-
 
         typedef _DataTypes DataTypes;
         typedef typename DataTypes::Deriv Deriv;
@@ -102,6 +107,7 @@ namespace sofa {
             MatrixDeriv& column = *columns.beginEdit();
             columns.endEdit();
 
+//            m_componentstate = ComponentState::Valid;
             this->buildConstraintMatrix(cparams, columns, columnsIndex, x);
 
             MatrixDeriv columnExpected;

--- a/tests/component/constraint/SurfacePressureConstraintTest.cpp
+++ b/tests/component/constraint/SurfacePressureConstraintTest.cpp
@@ -59,7 +59,7 @@ namespace sofa {
     struct SurfacePressureConstraintTest : public Sofa_test<typename _DataTypes::Real>, SurfacePressureConstraint<_DataTypes>
     {
 
-//        using SurfacePressureConstraint<_DataTypes>::m_componentstate;
+        using SurfacePressureConstraint<_DataTypes>::m_componentstate;
 
         simulation::Node::SPtr m_root;                 ///< Root of the scene graph, created by the constructor an re-used in the tests
         simulation::Simulation* m_simulation;          ///< created by the constructor an re-used in the tests
@@ -107,7 +107,7 @@ namespace sofa {
             MatrixDeriv& column = *columns.beginEdit();
             columns.endEdit();
 
-//            m_componentstate = ComponentState::Valid;
+            m_componentstate = ComponentState::Valid;
             this->buildConstraintMatrix(cparams, columns, columnsIndex, x);
 
             MatrixDeriv columnExpected;


### PR DESCRIPTION
This merge request contains some general cleaning, but mostly:   
I added the use of m_componentstate to avoid segfault (as Damien did on SoftRobots.Inverse/SlidingActuator)