### PR TITLE
[docs.tutorials] some fix, and cleaning to remove warnings in Tripod tutorial

### DIFF
--- a/docs/tutorials/Tripod/details/actuatedarm.py
+++ b/docs/tutorials/Tripod/details/actuatedarm.py
@@ -79,7 +79,7 @@ class ActuatedArm(object):
 
         if attachingTo != None:
             constraint = self.addConstraint(attachingTo.dofs.getData("rest_position"), translation, eulerRotation)
-            attachingTo.createObject('RestShapeSpringsForceField',
+            attachingTo.createObject('RestShapeSpringsForceField', name="rssff"+name,
                                      points = constraint.BoxROI.getData("indices"),
                                      external_rest_shape = constraint.dofs,
                                      stiffness='1e12')

--- a/docs/tutorials/Tripod/details/fixingbox.py
+++ b/docs/tutorials/Tripod/details/fixingbox.py
@@ -7,7 +7,7 @@ class FixingBox(SofaObject):
     def __init__(self, parent, target, name="FixingBox",
                  translation=[0.0,0.0,0.0], eulerRotation=[0.0,0.0,0.0], scale=[1.0,1.0,1.0]):
 
-        ob = getOrientedBoxFromTransform(translation, eulerRotation, scale)
+        ob = getOrientedBoxFromTransform(translation=translation, eulerRotation=eulerRotation, scale=scale)
 
         self.node = parent.createChild(name)
         self.node.createObject("BoxROI",
@@ -22,4 +22,3 @@ class FixingBox(SofaObject):
         c.createObject('RestShapeSpringsForceField',
                                                points=self.node.boxroi.getData("indices"),
                                                stiffness='1e12')
-

--- a/docs/tutorials/Tripod/details/step1.pyscn
+++ b/docs/tutorials/Tripod/details/step1.pyscn
@@ -8,6 +8,8 @@ from stlib.scene import Scene
 
 def createScene(rootNode):
     ## Setting the gravity, assuming the length unit is in centimeters
+    rootNode.createObject("RequiredPlugin", name="SofaSparseSolver")
+
     scene = Scene(rootNode, gravity=[0.0,-981.0,0.0])
 
     ## Setting the timestep in seconds
@@ -28,7 +30,7 @@ def createScene(rootNode):
                              rotation=[90.0,0.0,0.0])
     elasticbody.createObject("UniformMass")
 
-    elasticbody.createObject("EulerImplicit")
+    elasticbody.createObject("EulerImplicitSolver")
     elasticbody.createObject("SparseLDLSolver")
 
     ## Visual object

--- a/docs/tutorials/Tripod/details/step2.pyscn
+++ b/docs/tutorials/Tripod/details/step2.pyscn
@@ -6,6 +6,7 @@ from stlib.physics.deformable import ElasticMaterialObject
 from stlib.scene import Scene
 
 def createScene(rootNode):
+    rootNode.createObject("RequiredPlugin", name="SofaSparseSolver")
     scene = Scene(rootNode, gravity=[0.0,-9810.0,0.0])
 
     scene.dt = 0.001
@@ -36,7 +37,7 @@ def createScene(rootNode):
                               showObjectScale=5.0)
     elasticbody.createObject("UniformMass", totalMass=0.032)
 
-    elasticbody.createObject("EulerImplicit")
+    elasticbody.createObject("EulerImplicitSolver")
     elasticbody.createObject("SparseLDLSolver")
 
     # ForceField components

--- a/docs/tutorials/Tripod/details/step3.pyscn
+++ b/docs/tutorials/Tripod/details/step3.pyscn
@@ -51,7 +51,7 @@ def createScene(rootNode):
     fix = FixingBox(rootNode,
                     body.ElasticMaterialObject,
                     translation=[0.0,0.0,0.0],
-                    scale=[30,30,30])
+                    scale=[30.,30.,30.])
 
     # Changing the property of the Box ROI so that the constraint area appears on screen.
     fix.boxroi.drawBoxes=True

--- a/docs/tutorials/Tripod/details/step6.pyscn
+++ b/docs/tutorials/Tripod/details/step6.pyscn
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 import Sofa
 from stlib.scene import Scene, Interaction
-from splib.numerics import sin,cos, to_radians, RigidDof
+from splib.numerics import RigidDof
 from splib.animation import animate
-from stlib.scene import Scene
 from splib.constants import Key
 from math import floor, pi
 from tripod import Tripod
 
 def setupanimation(actuators, step, angularstep, rayonMin, rayonMax, factor):
+
     for actuator in actuators:
             rigid = RigidDof( actuator.dofs )
-            rigid.setPosition( rigid.getRestPosition() + rigid.forward * (rayonMax-rayonMin) * factor )
+            rigid.translate( rigid.forward * step * factor )
             actuator.ServoMotor.angle += angularstep * factor
 
 class MyController(Sofa.PythonScriptController):
@@ -53,7 +53,7 @@ class MyController(Sofa.PythonScriptController):
 
 ## Description of how the communication is handled
 def SerialPortBridgeGeneric(rootNode, serialport="/dev/ttyUSB0"):
-    return rootNode.createObject("SerialPortBridgeGeneric", port=serialport, baudRate=115200, size=3, listening=True)
+    return rootNode.createObject("SerialPortBridgeGeneric", port=serialport, baudRate=115200, size=3, listening=True, header=255)
 
 ## Data sending controller
 class SerialPortController(Sofa.PythonScriptController):
@@ -61,7 +61,7 @@ class SerialPortController(Sofa.PythonScriptController):
         self.name = "serialportcontroller"
         self.servos = inputs
         self.serialport = serialport
-        self.serialport.sentData = [150,150,150]
+        self.serialport.packetOut = [150,150,150]
         self.state = "init"
 
     def onEndAnimationStep(self, dt):
@@ -78,7 +78,7 @@ class SerialPortController(Sofa.PythonScriptController):
         for servo in self.servos:
             #conversion of the angle values from radians to degrees
             angleDegree = servo.angle*360/(2.0*pi)
-            angleByte = floor(angleDegree) + 179
+            angleByte = int(floor(angleDegree)) + 179
 
             #limitation of the angular position's command
             if angleByte < 60:
@@ -90,7 +90,7 @@ class SerialPortController(Sofa.PythonScriptController):
             angles.append( angleByte )
 
         # The controller board of the real robot receives `angles` values
-        self.serialport.sentData = angles
+        self.serialport.packetOut = angles
 
 def createScene(rootNode):
     scene = Scene(rootNode, gravity=[0.0,-981.0,0.0], plugins=["SoftRobots"])

--- a/docs/tutorials/Tripod/details/step7.pyscn
+++ b/docs/tutorials/Tripod/details/step7.pyscn
@@ -35,7 +35,7 @@ class JumpController(Sofa.PythonScriptController):
 
 def createScene(rootNode):
     scene = Scene(rootNode, gravity=[0,-9810,0])
-    scene.VisualStyle.displayFlags="showBehavior"
+    scene.VisualStyle.displayFlags="showForceFields"
 
     scene.createObject("MeshSTLLoader", name="loader", filename="data/mesh2/blueprint.stl")
     scene.createObject("OglModel", src="@loader")
@@ -46,7 +46,7 @@ def createScene(rootNode):
 
     model = scene.createChild("Model")
     Sphere(model, translation=[0.0,40.0,0.0],
-                  uniformScale=10,
+                  uniformScale=10.,
                   totalMass=0.0015)
 
     ## The new tripod prefab with the collision model on the top of the servomotors is implemented in the prefab TripodCollision in tripod.py and doesn't work yet

--- a/docs/tutorials/Tripod/details/step8.pyscn
+++ b/docs/tutorials/Tripod/details/step8.pyscn
@@ -15,8 +15,10 @@ from stlib.physics.rigid import Sphere
 from tripod import Tripod
 from tripodcontroller import MyController
 
+
 class JumpController(Sofa.PythonScriptController):
     """Press Z/Q to play with the ball"""
+
     def __init__(self, node, actuators):
         self.actuators = actuators
         self.name = "JumpController"
@@ -28,13 +30,14 @@ class JumpController(Sofa.PythonScriptController):
         if key == Key.Q:
             apos = -3.14/3
 
-        if apos != None:
+        if apos is not None:
             for actuator in self.actuators:
                 actuator.ServoMotor.angle = apos
 
+
 def createScene(rootNode):
-    scene = Scene(rootNode, gravity=[0,-9810,0])
-    scene.VisualStyle.displayFlags="showBehavior"
+    scene = Scene(rootNode, gravity=[0, -9810, 0])
+    scene.VisualStyle.displayFlags = "showForceFields"
 
     scene.createObject("MeshSTLLoader", name="loader", filename="data/mesh2/blueprint.stl")
     scene.createObject("OglModel", src="@loader")
@@ -43,9 +46,9 @@ def createScene(rootNode):
                      contactDistance=2)
 
     model = scene.createChild("Model")
-    Sphere(model, translation=[0.0,40.0,0.0],
-                  uniformScale=10,
-                  totalMass=0.0015)
+    Sphere(model, translation=[0.0, 40.0, 0.0],
+           uniformScale=10,
+           totalMass=0.0015)
 
     tripod = Tripod(model)
 

--- a/docs/tutorials/Tripod/details/tripod.py
+++ b/docs/tutorials/Tripod/details/tripod.py
@@ -18,14 +18,13 @@ def ElasticBody(parent):
                         rotation=[90,0,0], translation=[0,30,0])
 
     visual.createObject("BarycentricMapping",
-                             input=e.dofs.getLinkPath(),
-                             output=visual.renderer.getLinkPath())
+                         input=e.dofs.getLinkPath(),
+                         output=visual.renderer.getLinkPath())
 
     # j ai modifie la fonction de collision so I could add a collisionGroup
     #e.addCollisionModel(collisionMesh="data/mesh2/tripod_low.stl",
     #                    translation=[0.0,30,0.0], rotation=[90,0,0])
-    CollisionMesh(e,
-         surfaceMeshFileName="data/mesh2/tripod_low.stl", name="silicone", translation=[0.0,30,0.0], rotation=[90,0,0], collisionGroup=1)
+    CollisionMesh(e, surfaceMeshFileName="data/mesh2/tripod_low.stl", name="silicone", translation=[0.0,30,0.0], rotation=[90,0,0], collisionGroup=1)
 
     return body
 
@@ -45,8 +44,8 @@ def Tripod(parent, name="Tripod", radius=65, numMotors=3, angleShift=180.0):
         translation = [dist*sin(to_radians(angle2)), -1.35, dist*cos(to_radians(angle2))]
 
         c = ActuatedArm(tripod, name=name,
-                                       translation=translation, eulerRotation=eulerRotation,
-                                       attachingTo=body.ElasticMaterialObject)
+                        translation=translation, eulerRotation=eulerRotation,
+                        attachingTo=body.ElasticMaterialObject)
     return tripod
 
 ## Mon bricolage a partir d ici
@@ -66,12 +65,12 @@ def TripodCollision(parent, name="Tripod+Collision", radius=65, numMotors=3, ang
         translation = [dist*sin(to_radians(angle2)), -1.35, dist*cos(to_radians(angle2))]
 
         c = ActuatedArm(tripod, name=name,
-                                       translation=translation, eulerRotation=eulerRotation,
-                                       attachingTo=body.ElasticMaterialObject)
+                        translation=translation, eulerRotation=eulerRotation,
+                        attachingTo=body.ElasticMaterialObject)
         translationServoTops=[dist*sin(to_radians(angle2)), -0.0, dist*cos(to_radians(angle2))+55.0]
 
         CollisionMesh(c.ServoMotor,
-                 surfaceMeshFileName="data/mesh2/servo_collision.stl",
-                 name="TopServo"+str(i), collisionGroup=1, mappingType='RigidMapping')
+                      surfaceMeshFileName="data/mesh2/servo_collision.stl",
+                      name="TopServo"+str(i), collisionGroup=1, mappingType='RigidMapping')
 
     return tripod

--- a/docs/tutorials/Tripod/details/tripodcontroller.py
+++ b/docs/tutorials/Tripod/details/tripodcontroller.py
@@ -10,7 +10,7 @@ def setupanimation(actuators, step, angularstep, rayonMin, rayonMax, factor):
     """
     for actuator in actuators:
             rigid = RigidDof( actuator.dofs )
-            rigid.setPosition( rigid.getRestPosition() + rigid.forward * (rayonMax-rayonMin) * factor )
+            rigid.translate( rigid.forward * step * factor )
             actuator.ServoMotor.angle += angularstep * factor
 
 class MyController(Sofa.PythonScriptController):

--- a/src/SoftRobots/component/controller/SerialPortBridgeGeneric.cpp
+++ b/src/SoftRobots/component/controller/SerialPortBridgeGeneric.cpp
@@ -149,7 +149,8 @@ void SerialPortBridgeGeneric::init()
 // To remove before v20.0 of the plugin
 void SerialPortBridgeGeneric::dataDeprecationManagement()
 {
-    msg_warning() << "An old implementation was using 245 as the default header for sentData. This is not the case anymore. The default header is now equal to 255.";
+    if(!d_header.isSet())
+        msg_warning() << "An old implementation was using 245 as the default header for sentData. This is not the case anymore. The default header is now equal to 255.";
 
     if(d_precise.getValue())
         msg_warning() << "An old implementation was multiplying the values of sentData by 1000 when setting precise=true. This is not the case anymore.";


### PR DESCRIPTION
There were some problems with:
-fixingbox's call to getOrientedBoxFromTransform()
-setupanimation in step6 and step7

Other changes are to remove warnings. 