### PR TITLE
first sofapython3 scene (Finger with cable constraints)

### DIFF
--- a/docs/examples/component/constraint/CableConstraint/sofapython3/Finger.py3
+++ b/docs/examples/component/constraint/CableConstraint/sofapython3/Finger.py3
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+
+import Sofa
+import Sofa.Core
+
+import os
+
+path = os.path.dirname(os.path.abspath(__file__))+'../mesh/'
+from FingerController import FingerController
+
+def createScene(rootNode):
+                rootNode.createObject('RequiredPlugin', pluginName='SoftRobots')
+                rootNode.createObject('VisualStyle', displayFlags='showVisualModels hideBehaviorModels showCollisionModels hideBoundingCollisionModels hideForceFields showInteractionForceFields hideWireframe')
+
+                rootNode.createObject('FreeMotionAnimationLoop')
+
+                # Add a QPInverseProblemSolver to the scene if you need to solve inverse problem like the one that involved
+                # when manipulating the robots by specifying their effector's position instead of by direct control
+                # of the actuator's parameters.
+                #rootNode.createObject('QPInverseProblemSolver', printLog='1')
+                # Otherwise use a GenericConstraintSolver
+                rootNode.createObject('GenericConstraintSolver', tolerance="1e-5", maxIterations="100")
+
+                rootNode.gravity = [0, -9810, 0]
+                rootNode.dt=0.01
+                rootNode.createObject('BackgroundSetting', color='0 0.168627 0.211765')
+                rootNode.createObject('OglSceneFrame', style="Arrows", alignment="TopRight")
+
+                ##########################################
+                # FEM Model                              #
+                ##########################################
+                finger = rootNode.createChild('finger')
+                finger.createObject('EulerImplicit', name='odesolver', firstOrder='0', rayleighMass="0.1", rayleighStiffness="0.1")
+                finger.createObject('SparseLDLSolver', name='preconditioner')
+
+		        # Add a componant to load a VTK tetrahedral mesh and expose the resulting topology in the scene .
+                finger.createObject('MeshVTKLoader', name='loader', filename=path+'finger.vtk')
+                finger.createObject('TetrahedronSetTopologyContainer', src='@loader', name='container')
+                finger.createObject('TetrahedronSetTopologyModifier')
+                finger.createObject('TetrahedronSetTopologyAlgorithms', template='Vec3d')
+                finger.createObject('TetrahedronSetGeometryAlgorithms', template='Vec3d')
+
+                # Create a mechanicaobject component to stores the DoFs of the model
+                finger.createObject('MechanicalObject', name='tetras', template='Vec3d', showIndices='false', showIndicesScale='4e-5', rx='0', dz='0')
+
+                # Gives a mass to the model
+                finger.createObject('UniformMass', totalMass='0.075')
+
+                # Add a TetrahedronFEMForceField componant which implement an elastic material model solved using the Finite Element Method on
+                # tetrahedrons.
+                finger.createObject('TetrahedronFEMForceField', template='Vec3d', name='FEM', method='large', poissonRatio='0.45',  youngModulus='600')
+
+                # To facilitate the selection of DoFs, SOFA has a concept called ROI (Region of Interest).
+		        # The idea is that ROI component "select" all DoFS that are enclosed by their "region".
+                # We use ROI here to select a group of finger's DoFs that will be constrained to stay
+                # at a fixed position.
+                # You can either use "BoxROI"...
+                finger.createObject('BoxROI', name='ROI1', box='-15 0 0 5 10 15', drawBoxes='true')
+                # Or "SphereROI"...
+                #finger.createObject('SphereROI', name='ROI', centers='0 0 0', radii='5')
+
+                # RestShapeSpringsForceField is one way in Sofa to implement fixed point constraint.
+                # Here the constraints are applied to the DoFs selected by the previously defined BoxROI
+                finger.createObject('RestShapeSpringsForceField', points='@ROI1.indices', stiffness='1e12')
+
+                # It is also possible to simply set by hand the indices of the points you want to fix.
+                #finger.createObject('RestShapeSpringsForceField', points='0 1 2 11 55', stiffness='1e12')
+
+                finger.createObject('LinearSolverConstraintCorrection')
+
+
+                ##########################################
+                # Cable                                  #
+                ##########################################
+
+                #  This create a new node in the scene. This node is appended to the finger's node.
+                cable = finger.createChild('cable')
+
+                # This create a MechanicalObject, a componant holding the degree of freedom of our
+                # mechanical modelling. In the case of a cable it is a set of positions specifying
+                # the points where the cable is passing by.
+                cable.createObject('MechanicalObject',
+                        position=(
+                                "-17.5 12.5 2.5 " +
+                                "-32.5 12.5 2.5 " +
+                                "-47.5 12.5 2.5 " +
+                                "-62.5 12.5 2.5 " +
+                                "-77.5 12.5 2.5 " +
+
+                                "-83.5 12.5 4.5 " +
+                                "-85.5 12.5 6.5 " +
+                                "-85.5 12.5 8.5 " +
+                                "-83.5 12.5 10.5 " +
+
+                                "-77.5 12.5 12.5 " +
+                                "-62.5 12.5 12.5 " +
+                                "-47.5 12.5 12.5 " +
+                                "-32.5 12.5 12.5 " +
+                                "-17.5 12.5 12.5 " ))
+
+                # Create a CableConstraint object with a name.
+                # the indices are referring to the MechanicalObject's positions.
+                # The last indice is where the pullPoint is connected.
+                cable.createObject('CableConstraint', name="aCableActuator",
+                        #indices=range(0,14),
+                        indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13",
+                        pullPoint="0.0 12.5 2.5")
+
+                # This create a BarycentricMapping. A BarycentricMapping is a key element as it will create a bi-directional link
+                # between the cable's DoFs and the finger's ones so that movements of the cable's DoFs will be mapped
+                # to the finger and vice-versa;
+                cable.createObject('BarycentricMapping')
+
+                # This create a PythonScriptController that permits to programatically implement new behavior
+                # or interactions using the Python programming langage. The controller is referring to a
+                # file named "controller.py".
+                cable.addObject(FingerController(node=cable))
+
+                ##########################################
+                # Visualization                          #
+                ##########################################
+                # In Sofa, visualization is handled by adding a rendering model.
+                # Create an empty child node to store this rendering model.
+                fingerVisu = finger.createChild('visu')
+
+                # Add to this empty node a rendering model made of triangles and loaded from an stl file.
+                fingerVisu.createObject('MeshSTLLoader', filename=path+"finger.stl", name="loader")
+                fingerVisu.createObject('OglModel', src="@loader", template='ExtVec3f', color="0.0 0.7 0.7")
+
+                # Add a BarycentricMapping to deform the rendering model in a way that follow the ones of the parent mechanical model.
+                fingerVisu.createObject('BarycentricMapping')
+
+                return rootNode

--- a/docs/examples/component/constraint/CableConstraint/sofapython3/Finger.py3
+++ b/docs/examples/component/constraint/CableConstraint/sofapython3/Finger.py3
@@ -9,64 +9,64 @@ path = os.path.dirname(os.path.abspath(__file__))+'../mesh/'
 from FingerController import FingerController
 
 def createScene(rootNode):
-                rootNode.createObject('RequiredPlugin', pluginName='SoftRobots')
-                rootNode.createObject('VisualStyle', displayFlags='showVisualModels hideBehaviorModels showCollisionModels hideBoundingCollisionModels hideForceFields showInteractionForceFields hideWireframe')
+                rootNode.addObject('RequiredPlugin', pluginName='SoftRobots')
+                rootNode.addObject('VisualStyle', displayFlags='showVisualModels hideBehaviorModels showCollisionModels hideBoundingCollisionModels hideForceFields showInteractionForceFields hideWireframe')
 
-                rootNode.createObject('FreeMotionAnimationLoop')
+                rootNode.addObject('FreeMotionAnimationLoop')
 
                 # Add a QPInverseProblemSolver to the scene if you need to solve inverse problem like the one that involved
                 # when manipulating the robots by specifying their effector's position instead of by direct control
                 # of the actuator's parameters.
-                #rootNode.createObject('QPInverseProblemSolver', printLog='1')
+                #rootNode.addObject('QPInverseProblemSolver', printLog='1')
                 # Otherwise use a GenericConstraintSolver
-                rootNode.createObject('GenericConstraintSolver', tolerance="1e-5", maxIterations="100")
+                rootNode.addObject('GenericConstraintSolver', tolerance="1e-5", maxIterations="100")
 
                 rootNode.gravity = [0, -9810, 0]
                 rootNode.dt=0.01
-                rootNode.createObject('BackgroundSetting', color='0 0.168627 0.211765')
-                rootNode.createObject('OglSceneFrame', style="Arrows", alignment="TopRight")
+                rootNode.addObject('BackgroundSetting', color='0 0.168627 0.211765')
+                rootNode.addObject('OglSceneFrame', style="Arrows", alignment="TopRight")
 
                 ##########################################
                 # FEM Model                              #
                 ##########################################
-                finger = rootNode.createChild('finger')
-                finger.createObject('EulerImplicit', name='odesolver', firstOrder='0', rayleighMass="0.1", rayleighStiffness="0.1")
-                finger.createObject('SparseLDLSolver', name='preconditioner')
+                finger = rootNode.addChild('finger')
+                finger.addObject('EulerImplicit', name='odesolver', firstOrder='0', rayleighMass="0.1", rayleighStiffness="0.1")
+                finger.addObject('SparseLDLSolver', name='preconditioner')
 
 		        # Add a componant to load a VTK tetrahedral mesh and expose the resulting topology in the scene .
-                finger.createObject('MeshVTKLoader', name='loader', filename=path+'finger.vtk')
-                finger.createObject('TetrahedronSetTopologyContainer', src='@loader', name='container')
-                finger.createObject('TetrahedronSetTopologyModifier')
-                finger.createObject('TetrahedronSetTopologyAlgorithms', template='Vec3d')
-                finger.createObject('TetrahedronSetGeometryAlgorithms', template='Vec3d')
+                finger.addObject('MeshVTKLoader', name='loader', filename=path+'finger.vtk')
+                finger.addObject('TetrahedronSetTopologyContainer', src='@loader', name='container')
+                finger.addObject('TetrahedronSetTopologyModifier')
+                finger.addObject('TetrahedronSetTopologyAlgorithms', template='Vec3d')
+                finger.addObject('TetrahedronSetGeometryAlgorithms', template='Vec3d')
 
                 # Create a mechanicaobject component to stores the DoFs of the model
-                finger.createObject('MechanicalObject', name='tetras', template='Vec3d', showIndices='false', showIndicesScale='4e-5', rx='0', dz='0')
+                finger.addObject('MechanicalObject', name='tetras', template='Vec3d', showIndices='false', showIndicesScale='4e-5', rx='0', dz='0')
 
                 # Gives a mass to the model
-                finger.createObject('UniformMass', totalMass='0.075')
+                finger.addObject('UniformMass', totalMass='0.075')
 
                 # Add a TetrahedronFEMForceField componant which implement an elastic material model solved using the Finite Element Method on
                 # tetrahedrons.
-                finger.createObject('TetrahedronFEMForceField', template='Vec3d', name='FEM', method='large', poissonRatio='0.45',  youngModulus='600')
+                finger.addObject('TetrahedronFEMForceField', template='Vec3d', name='FEM', method='large', poissonRatio='0.45',  youngModulus='600')
 
                 # To facilitate the selection of DoFs, SOFA has a concept called ROI (Region of Interest).
 		        # The idea is that ROI component "select" all DoFS that are enclosed by their "region".
                 # We use ROI here to select a group of finger's DoFs that will be constrained to stay
                 # at a fixed position.
                 # You can either use "BoxROI"...
-                finger.createObject('BoxROI', name='ROI1', box='-15 0 0 5 10 15', drawBoxes='true')
+                finger.addObject('BoxROI', name='ROI1', box='-15 0 0 5 10 15', drawBoxes='true')
                 # Or "SphereROI"...
-                #finger.createObject('SphereROI', name='ROI', centers='0 0 0', radii='5')
+                #finger.addObject('SphereROI', name='ROI', centers='0 0 0', radii='5')
 
                 # RestShapeSpringsForceField is one way in Sofa to implement fixed point constraint.
                 # Here the constraints are applied to the DoFs selected by the previously defined BoxROI
-                finger.createObject('RestShapeSpringsForceField', points='@ROI1.indices', stiffness='1e12')
+                finger.addObject('RestShapeSpringsForceField', points='@ROI1.indices', stiffness='1e12')
 
                 # It is also possible to simply set by hand the indices of the points you want to fix.
-                #finger.createObject('RestShapeSpringsForceField', points='0 1 2 11 55', stiffness='1e12')
+                #finger.addObject('RestShapeSpringsForceField', points='0 1 2 11 55', stiffness='1e12')
 
-                finger.createObject('LinearSolverConstraintCorrection')
+                finger.addObject('LinearSolverConstraintCorrection')
 
 
                 ##########################################
@@ -74,12 +74,12 @@ def createScene(rootNode):
                 ##########################################
 
                 #  This create a new node in the scene. This node is appended to the finger's node.
-                cable = finger.createChild('cable')
+                cable = finger.addChild('cable')
 
                 # This create a MechanicalObject, a componant holding the degree of freedom of our
                 # mechanical modelling. In the case of a cable it is a set of positions specifying
                 # the points where the cable is passing by.
-                cable.createObject('MechanicalObject',
+                cable.addObject('MechanicalObject',
                         position=(
                                 "-17.5 12.5 2.5 " +
                                 "-32.5 12.5 2.5 " +
@@ -101,7 +101,7 @@ def createScene(rootNode):
                 # Create a CableConstraint object with a name.
                 # the indices are referring to the MechanicalObject's positions.
                 # The last indice is where the pullPoint is connected.
-                cable.createObject('CableConstraint', name="aCableActuator",
+                cable.addObject('CableConstraint', name="aCableActuator",
                         #indices=range(0,14),
                         indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13",
                         pullPoint="0.0 12.5 2.5")
@@ -109,7 +109,7 @@ def createScene(rootNode):
                 # This create a BarycentricMapping. A BarycentricMapping is a key element as it will create a bi-directional link
                 # between the cable's DoFs and the finger's ones so that movements of the cable's DoFs will be mapped
                 # to the finger and vice-versa;
-                cable.createObject('BarycentricMapping')
+                cable.addObject('BarycentricMapping')
 
                 # This create a PythonScriptController that permits to programatically implement new behavior
                 # or interactions using the Python programming langage. The controller is referring to a
@@ -121,13 +121,13 @@ def createScene(rootNode):
                 ##########################################
                 # In Sofa, visualization is handled by adding a rendering model.
                 # Create an empty child node to store this rendering model.
-                fingerVisu = finger.createChild('visu')
+                fingerVisu = finger.addChild('visu')
 
                 # Add to this empty node a rendering model made of triangles and loaded from an stl file.
-                fingerVisu.createObject('MeshSTLLoader', filename=path+"finger.stl", name="loader")
-                fingerVisu.createObject('OglModel', src="@loader", template='ExtVec3f', color="0.0 0.7 0.7")
+                fingerVisu.addObject('MeshSTLLoader', filename=path+"finger.stl", name="loader")
+                fingerVisu.addObject('OglModel', src="@loader", template='ExtVec3f', color="0.0 0.7 0.7")
 
                 # Add a BarycentricMapping to deform the rendering model in a way that follow the ones of the parent mechanical model.
-                fingerVisu.createObject('BarycentricMapping')
+                fingerVisu.addObject('BarycentricMapping')
 
                 return rootNode

--- a/docs/examples/component/constraint/CableConstraint/sofapython3/Finger.py3
+++ b/docs/examples/component/constraint/CableConstraint/sofapython3/Finger.py3
@@ -19,18 +19,18 @@ def createScene(rootNode):
                 # of the actuator's parameters.
                 #rootNode.addObject('QPInverseProblemSolver', printLog='1')
                 # Otherwise use a GenericConstraintSolver
-                rootNode.addObject('GenericConstraintSolver', tolerance="1e-5", maxIterations="100")
+                rootNode.addObject('GenericConstraintSolver', tolerance=1e-5, maxIterations=100)
 
                 rootNode.gravity = [0, -9810, 0]
-                rootNode.dt=0.01
-                rootNode.addObject('BackgroundSetting', color='0 0.168627 0.211765')
+                rootNode.dt = 0.01
+                rootNode.addObject('BackgroundSetting', color=[0, 0.168627, 0.211765])
                 rootNode.addObject('OglSceneFrame', style="Arrows", alignment="TopRight")
 
                 ##########################################
                 # FEM Model                              #
                 ##########################################
                 finger = rootNode.addChild('finger')
-                finger.addObject('EulerImplicit', name='odesolver', firstOrder='0', rayleighMass="0.1", rayleighStiffness="0.1")
+                finger.addObject('EulerImplicit', name='odesolver', rayleighMass=0.1, rayleighStiffness=0.1)
                 finger.addObject('SparseLDLSolver', name='preconditioner')
 
 		        # Add a componant to load a VTK tetrahedral mesh and expose the resulting topology in the scene .
@@ -41,27 +41,27 @@ def createScene(rootNode):
                 finger.addObject('TetrahedronSetGeometryAlgorithms', template='Vec3d')
 
                 # Create a mechanicaobject component to stores the DoFs of the model
-                finger.addObject('MechanicalObject', name='tetras', template='Vec3d', showIndices='false', showIndicesScale='4e-5', rx='0', dz='0')
+                finger.addObject('MechanicalObject', name='tetras', template='Vec3d', showIndices=False, showIndicesScale=4e-5)
 
                 # Gives a mass to the model
-                finger.addObject('UniformMass', totalMass='0.075')
+                finger.addObject('UniformMass', totalMass=0.075)
 
                 # Add a TetrahedronFEMForceField componant which implement an elastic material model solved using the Finite Element Method on
                 # tetrahedrons.
-                finger.addObject('TetrahedronFEMForceField', template='Vec3d', name='FEM', method='large', poissonRatio='0.45',  youngModulus='600')
+                finger.addObject('TetrahedronFEMForceField', template='Vec3d', name='FEM', method='large', poissonRatio=0.45,  youngModulus=600)
 
                 # To facilitate the selection of DoFs, SOFA has a concept called ROI (Region of Interest).
 		        # The idea is that ROI component "select" all DoFS that are enclosed by their "region".
                 # We use ROI here to select a group of finger's DoFs that will be constrained to stay
                 # at a fixed position.
                 # You can either use "BoxROI"...
-                finger.addObject('BoxROI', name='ROI1', box='-15 0 0 5 10 15', drawBoxes='true')
+                finger.addObject('BoxROI', name='ROI1', box=[-15, 0, 0, 5, 10, 15], drawBoxes=True)
                 # Or "SphereROI"...
                 #finger.addObject('SphereROI', name='ROI', centers='0 0 0', radii='5')
 
                 # RestShapeSpringsForceField is one way in Sofa to implement fixed point constraint.
                 # Here the constraints are applied to the DoFs selected by the previously defined BoxROI
-                finger.addObject('RestShapeSpringsForceField', points='@ROI1.indices', stiffness='1e12')
+                finger.addObject('RestShapeSpringsForceField', points='@ROI1.indices', stiffness=1e12)
 
                 # It is also possible to simply set by hand the indices of the points you want to fix.
                 #finger.addObject('RestShapeSpringsForceField', points='0 1 2 11 55', stiffness='1e12')
@@ -80,31 +80,31 @@ def createScene(rootNode):
                 # mechanical modelling. In the case of a cable it is a set of positions specifying
                 # the points where the cable is passing by.
                 cable.addObject('MechanicalObject',
-                        position=(
-                                "-17.5 12.5 2.5 " +
-                                "-32.5 12.5 2.5 " +
-                                "-47.5 12.5 2.5 " +
-                                "-62.5 12.5 2.5 " +
-                                "-77.5 12.5 2.5 " +
+                        position=[
+                                [-17.5, 12.5, 2.5],
+                                [-32.5, 12.5, 2.5],
+                                [-47.5, 12.5, 2.5],
+                                [-62.5, 12.5, 2.5],
+                                [-77.5, 12.5, 2.5],
 
-                                "-83.5 12.5 4.5 " +
-                                "-85.5 12.5 6.5 " +
-                                "-85.5 12.5 8.5 " +
-                                "-83.5 12.5 10.5 " +
+                                [-85.5, 12.5, 6.5],
+                                [-85.5, 12.5, 8.5],
+                                [-83.5, 12.5, 4.5],
+                                [-83.5, 12.5, 10.5],
 
-                                "-77.5 12.5 12.5 " +
-                                "-62.5 12.5 12.5 " +
-                                "-47.5 12.5 12.5 " +
-                                "-32.5 12.5 12.5 " +
-                                "-17.5 12.5 12.5 " ))
+                                [-77.5, 12.5, 12.5],
+                                [-62.5, 12.5, 12.5],
+                                [-47.5, 12.5, 12.5],
+                                [-32.5, 12.5, 12.5],
+                                [-17.5, 12.5, 12.5]])
 
                 # Create a CableConstraint object with a name.
                 # the indices are referring to the MechanicalObject's positions.
                 # The last indice is where the pullPoint is connected.
                 cable.addObject('CableConstraint', name="aCableActuator",
                         #indices=range(0,14),
-                        indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13",
-                        pullPoint="0.0 12.5 2.5")
+                        indices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+                        pullPoint=[0.0, 12.5, 2.5])
 
                 # This create a BarycentricMapping. A BarycentricMapping is a key element as it will create a bi-directional link
                 # between the cable's DoFs and the finger's ones so that movements of the cable's DoFs will be mapped
@@ -125,7 +125,7 @@ def createScene(rootNode):
 
                 # Add to this empty node a rendering model made of triangles and loaded from an stl file.
                 fingerVisu.addObject('MeshSTLLoader', filename=path+"finger.stl", name="loader")
-                fingerVisu.addObject('OglModel', src="@loader", template='ExtVec3f', color="0.0 0.7 0.7")
+                fingerVisu.addObject('OglModel', src="@loader", template='ExtVec3f', color=[0.0, 0.7, 0.7])
 
                 # Add a BarycentricMapping to deform the rendering model in a way that follow the ones of the parent mechanical model.
                 fingerVisu.addObject('BarycentricMapping')

--- a/docs/examples/component/constraint/CableConstraint/sofapython3/FingerController.py
+++ b/docs/examples/component/constraint/CableConstraint/sofapython3/FingerController.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import Sofa.Core
+
+class FingerController(Sofa.Core.Controller):
+    """
+    This Controller simply takes the cableActuator's value
+    and increases / decreases it depending on the pressed key ('+' or '-')
+    """
+    def __init__(self, *a, **kw):
+        """
+        In the ctor, we want to first call the constructor for the parent class (trampoline)
+        We then store the node we want to retrieve the actuator from in the class
+        (Sofa.Core.Base.getContext() could also have been used here instead,
+        or a link between aCableActuator and the controller could have been used too)
+        """
+        Sofa.Core.Controller.__init__(self, *a, **kw)
+        self.node = kw["node"]
+        return
+    
+    def onKeypressedEvent(self,e):
+        """
+        Events methods are named after the actual event names (Event::GetClassName() in C++),
+        with a prepended "on" prefix. Thus this Event is the KeypressedEvent class in C++
+        The onXXXEvent method takes a dictionary as a parameter, containing the useful
+        values stored in the event class, e.g. here, the pressed key
+        """
+        inputvalue = self.node.aCableActuator.value
+        
+        displacement = 0
+        if (e["key"] == "+"):
+            displacement = inputvalue.value[0] + 1.0
+        elif (e["key"] == "-"):
+            displacement = inputvalue.value[0] - 1.0
+            if(displacement < 0):
+                displacement = 0
+                
+        inputvalue.value = [displacement]
+        return

--- a/docs/examples/component/constraint/CableConstraint/sofapython3/FingerController.py
+++ b/docs/examples/component/constraint/CableConstraint/sofapython3/FingerController.py
@@ -18,7 +18,7 @@ class FingerController(Sofa.Core.Controller):
         Sofa.Core.Controller.__init__(self, *a, **kw)
         self.node = kw["node"]
         return
-    
+
     def onKeypressedEvent(self,e):
         """
         Events methods are named after the actual event names (Event::GetClassName() in C++),
@@ -27,14 +27,14 @@ class FingerController(Sofa.Core.Controller):
         values stored in the event class, e.g. here, the pressed key
         """
         inputvalue = self.node.aCableActuator.value
-        
+
         displacement = 0
-        if (e["key"] == "+"):
+        if (e["key"] == Sofa.constants.key_plus):
             displacement = inputvalue.value[0] + 1.0
-        elif (e["key"] == "-"):
+        elif (e["key"] == Sofa.constants.key_minus):
             displacement = inputvalue.value[0] - 1.0
             if(displacement < 0):
                 displacement = 0
-                
+
         inputvalue.value = [displacement]
         return


### PR DESCRIPTION
A full tutorial scene converted from SofaPython (2) to SofaPython3.

Not much changes between the 2 APIs:

- `createObject` / `createChild` is deprecated in favor of `addChild` / `addObject`
- Controllers change slightly:
    -- constructors must call parent class's ctor
    -- event methods are now clearly named after their event type (`onBeginAnimationStep` becomes `onAnimateBeginEvent`) (prefix `on` is added to the return value of `Event::GetClassName()`)
    -- all event method takes a dict as a parameter, containing all useful values (instead of directly feeding them as arguments to the function
    -- it is not possible any more to create a controller using the `createObject` method on nodes. Instead their constructors should be called and then the instance is assigned to an `addObject` call.
- we cannot anymore assign values "the old XML-style way" meaning that stuff like `root.gravitiy = "0, -9.8, 0"` HAVE TO be replaced with `root.gravity = [0, 9.8, 0]`

That's all that changes between the SofaPython and the SofaPyhton3 version!
