### PR TITLE
[constraint] Warnings for the dependence between the force and dt

### DIFF
--- a/src/SoftRobots/component/constraint/model/AffineFunctionModel.inl
+++ b/src/SoftRobots/component/constraint/model/AffineFunctionModel.inl
@@ -63,7 +63,7 @@ AffineFunctionModel<DataTypes>::AffineFunctionModel(MechanicalState* object)
 
     , d_functionValue(initData(&d_functionValue, Real(0.0), "functionValue","Function value."))
 
-    , d_force(initData(&d_force,double(0.0), "force", "Output force."))
+    , d_force(initData(&d_force,double(0.0), "force", "Output force. Warning: to get the actual force you should divide this value by dt."))
 
     , d_displacement(initData(&d_displacement,double(0.0), "displacement",
                           "Output function value compared to the initial function value."))
@@ -160,9 +160,7 @@ void AffineFunctionModel<DataTypes>::checkSizes()
 	for (unsigned int i = 0; i<d_indices.getValue().size(); i++)
 	{
 		if (positions.size() <= d_indices.getValue()[i])
-			msg_error() << "Indices at index " << i << " is too large regarding mechanicalState [position] size";
-		if (d_indices.getValue()[i] < 0)
-			msg_error() << "Indices at index " << i << " is negative";
+            msg_error() << "Indices at index " << i << " is too large regarding mechanicalState [position] size";
 	}
 
     int nbIndices = d_indices.getValue().size();

--- a/src/SoftRobots/component/constraint/model/CableModel.inl
+++ b/src/SoftRobots/component/constraint/model/CableModel.inl
@@ -76,7 +76,7 @@ CableModel<DataTypes>::CableModel(MechanicalState* object)
     , d_cableLength(initData(&d_cableLength, Real(0.0), "cableLength","Computation done at the end of the time step"))
 
     , d_force(initData(&d_force,double(0.0), "force",
-                                         "Output force."))
+                                         "Output force. Warning: to get the actual force you should divide this value by dt."))
 
     , d_displacement(initData(&d_displacement,double(0.0), "displacement",
                           "Output displacement compared to the initial cable length."))
@@ -257,8 +257,6 @@ void CableModel<DataTypes>::checkIndicesRegardingState()
     {
         if (positions.size() <= d_indices.getValue()[i])
             msg_error() << "Indices at index " << i << " is too large regarding mechanicalState [position] size" ;
-        if (d_indices.getValue()[i] < 0)
-            msg_error() << "Indices at index " << i << " is negative" ;
     }
 }
 

--- a/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
+++ b/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
@@ -82,7 +82,7 @@ SurfacePressureModel<DataTypes>::SurfacePressureModel(MechanicalState* object)
                                "flipNormal to true."))
 
     , d_pressure(initData(&d_pressure, double(0.0), "pressure",
-                             "Output pressure."))
+                             "Output pressure. Warning: to get the actual pressure you should divide this value by dt."))
 
 
     , d_maxPressure(initData(&d_maxPressure, "maxPressure",
@@ -253,10 +253,6 @@ void SurfacePressureModel<DataTypes>::internalInit()
     auto triangles = d_triangles.getValue() ;
     for(int i=0;i<numTris;i++){
         for(int j=0;j<3;j++){
-            if( triangles[i][j] < 0 )
-                msg_error() << "triangles[" << i << "]["<< j << "]="<< triangles[i][j]
-                                   <<". is too small regarding mechanicalState size of(" << positions.size() << ")" ;
-
             if( triangles[i][j] >= positions.size() )
                 msg_error() << "triangles[" << i << "]["<< j << "]="<< triangles[i][j]
                                    <<". is too large regarding mechanicalState size of(" << positions.size() << ")" ;
@@ -269,11 +265,6 @@ void SurfacePressureModel<DataTypes>::internalInit()
     auto quads = d_quads.getValue() ;
     for(int i=0;i<numQuads;i++){
         for(int j=0;j<4;j++){
-            if( quads[i][j] < 0 )
-                msg_error() << "quads [" <<i << "][" << j << "]=" << quads[i][j]
-                                   << " is too small regarding mechanicalState size of("
-                                   << positions.size() << ")" ;
-
             if( quads[i][j] >= positions.size() )
                 msg_error() << "quads [" <<i << "][" << j << "]=" << quads[i][j]
                                    << " is too large regarding mechanicalState size of("


### PR DESCRIPTION
This PR:
- adds a warning info about the dependence between the "force" and dt in constraint components
- removes compilation warnings about `<0` always being false due to the variable type 