### PR TITLE
[all] Fix warnings for v22.06

### DIFF
--- a/src/SoftRobots/component/behavior/SoftRobotsConstraint.inl
+++ b/src/SoftRobots/component/behavior/SoftRobotsConstraint.inl
@@ -31,7 +31,7 @@
 #define SOFA_CORE_BEHAVIOR_SoftRobotsConstraint_INL
 
 #include "SoftRobotsConstraint.h"
-#include <SofaBaseLinearSolver/FullMatrix.h>
+#include <sofa/linearalgebra/FullMatrix.h>
 #include <sofa/core/ConstraintParams.h>
 
 namespace sofa
@@ -43,7 +43,7 @@ namespace core
 namespace behavior
 {
 
-using component::linearsolver::FullVector;
+using sofa::linearalgebra::FullVector;
 using helper::ReadAccessor;
 
 template<class DataTypes>

--- a/src/SoftRobots/component/constraint/UnilateralPlaneConstraint.h
+++ b/src/SoftRobots/component/constraint/UnilateralPlaneConstraint.h
@@ -34,7 +34,7 @@
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ConstraintParams.h>
-#include <sofa/defaulttype/BaseVector.h>
+#include <sofa/linearalgebra/BaseVector.h>
 #include <sofa/type/Vec.h>
 
 #include <SoftRobots/component/initSoftRobots.h>

--- a/src/SoftRobots/component/constraint/UnilateralPlaneConstraint.inl
+++ b/src/SoftRobots/component/constraint/UnilateralPlaneConstraint.inl
@@ -112,8 +112,6 @@ void UnilateralPlaneConstraint<DataTypes>::checkIndicesRegardingState()
     {
         if (positions.size() <= d_indices.getValue()[i])
             msg_error() << "Indices at index " << i << " is to large regarding mechanicalState [position] size" ;
-        if (d_indices.getValue()[i] < 0)
-            msg_error() << "Indices at index " << i << " is negative" ;
     }
 }
 

--- a/src/SoftRobots/component/controller/AnimationEditor.inl
+++ b/src/SoftRobots/component/controller/AnimationEditor.inl
@@ -441,10 +441,9 @@ void AnimationEditor<DataTypes>::moveCursor(const char key)
         }
     }
 
-    if (d_cursor.getValue()<0)
+    if (d_cursor.getValue()==0)
     {
         m_isFrameDirty = false;
-        d_cursor.setValue(0);
     }
 
     if (d_cursor.getValue()>d_maxKeyFrame.getValue())

--- a/tests/component/constraint/SurfacePressureConstraintTest.cpp
+++ b/tests/component/constraint/SurfacePressureConstraintTest.cpp
@@ -33,7 +33,7 @@
 #include <SoftRobots/component/constraint/SurfacePressureConstraint.h>
 using sofa::component::constraintset::SurfacePressureConstraint;
 
-#include <SofaBaseLinearSolver/FullVector.h>
+#include <sofa/linearalgebra/FullVector.h>
 #include <sofa/helper/BackTrace.h>
 #include <sofa/helper/system/Locale.h>
 

--- a/tests/component/constraint/UnilateralPlaneConstraintTest.cpp
+++ b/tests/component/constraint/UnilateralPlaneConstraintTest.cpp
@@ -35,7 +35,7 @@ using std::string ;
 #include <sofa/helper/BackTrace.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 
-#include <SofaBaseLinearSolver/FullVector.h>
+#include <sofa/linearalgebra/FullVector.h>
 using sofa::core::topology::BaseMeshTopology ;
 using sofa::core::objectmodel::Data ;
 
@@ -52,7 +52,7 @@ using sofa::simulation::Node ;
 using sofa::simulation::setSimulation ;
 using sofa::core::objectmodel::New ;
 using sofa::core::objectmodel::BaseData ;
-using sofa::component::container::MechanicalObject ;
+using sofa::component::statecontainer::MechanicalObject ;
 
 #include <SoftRobots/component/constraint/UnilateralPlaneConstraint.h>
 using sofa::component::constraintset::UnilateralPlaneConstraint ;

--- a/tests/component/controller/AnimationEditorTest.cpp
+++ b/tests/component/controller/AnimationEditorTest.cpp
@@ -37,7 +37,7 @@ using std::string ;
 #include <sofa/simulation/DefaultAnimationLoop.h>
 using sofa::simulation::DefaultAnimationLoop;
 
-#include <SofaBaseLinearSolver/FullVector.h>
+#include <sofa/linearalgebra/FullVector.h>
 using sofa::core::topology::BaseMeshTopology ;
 using sofa::core::objectmodel::Data ;
 
@@ -48,7 +48,7 @@ using sofa::simulation::Node ;
 using sofa::simulation::setSimulation ;
 using sofa::core::objectmodel::New ;
 using sofa::core::objectmodel::BaseData ;
-using sofa::component::container::MechanicalObject ;
+using sofa::component::statecontainer::MechanicalObject ;
 
 #include <SofaSimulationCommon/SceneLoaderXML.h>
 using sofa::simulation::SceneLoaderXML ;

--- a/tests/component/controller/DataVariationLimiterTest.cpp
+++ b/tests/component/controller/DataVariationLimiterTest.cpp
@@ -34,7 +34,7 @@ using std::string ;
 #include <sofa/testing/BaseTest.h>
 #include <sofa/helper/BackTrace.h>
 
-#include <SofaBaseLinearSolver/FullVector.h>
+#include <sofa/linearalgebra/FullVector.h>
 
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::Simulation ;

--- a/tests/component/controller/SerialPortBridgeGenericTest.cpp
+++ b/tests/component/controller/SerialPortBridgeGenericTest.cpp
@@ -34,7 +34,7 @@ using std::string ;
 #include <sofa/testing/BaseTest.h>
 #include <sofa/helper/BackTrace.h>
 
-#include <SofaBaseLinearSolver/FullVector.h>
+#include <sofa/linearalgebra/FullVector.h>
 
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::Simulation ;

--- a/tests/component/engine/VolumeFromTetrahedronsTest.cpp
+++ b/tests/component/engine/VolumeFromTetrahedronsTest.cpp
@@ -35,7 +35,7 @@ using std::string ;
 #include <sofa/helper/BackTrace.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 
-#include <SofaBaseLinearSolver/FullVector.h>
+#include <sofa/linearalgebra/FullVector.h>
 using sofa::core::topology::BaseMeshTopology ;
 using sofa::core::objectmodel::Data ;
 
@@ -55,7 +55,7 @@ using sofa::simulation::Node ;
 using sofa::simulation::setSimulation ;
 using sofa::core::objectmodel::New ;
 using sofa::core::objectmodel::BaseData ;
-using sofa::component::container::MechanicalObject ;
+using sofa::component::statecontainer::MechanicalObject ;
 
 #include <SoftRobots/component/engine/VolumeFromTetrahedrons.h>
 using sofa::component::engine::VolumeFromTetrahedrons ;

--- a/tests/component/engine/VolumeFromTrianglesTest.cpp
+++ b/tests/component/engine/VolumeFromTrianglesTest.cpp
@@ -35,7 +35,7 @@ using std::string ;
 #include <sofa/helper/BackTrace.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 
-#include <SofaBaseLinearSolver/FullVector.h>
+#include <sofa/linearalgebra/FullVector.h>
 using sofa::core::topology::BaseMeshTopology ;
 using sofa::core::objectmodel::Data ;
 
@@ -55,7 +55,7 @@ using sofa::simulation::Node ;
 using sofa::simulation::setSimulation ;
 using sofa::core::objectmodel::New ;
 using sofa::core::objectmodel::BaseData ;
-using sofa::component::container::MechanicalObject ;
+using sofa::component::statecontainer::MechanicalObject ;
 
 #include <SoftRobots/component/engine/VolumeFromTriangles.h>
 using sofa::component::engine::VolumeFromTriangles ;


### PR DESCRIPTION
List of fixed warnings:

- new packaging:
    - linearalgebra
    - statecontainer
- <0 always false
- zmq deprecated methods