### PR TITLE
[constraint] adds PositionConstraint with example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ set(HEADER_FILES
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/CableConstraint.inl
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/PartialRigidificationConstraint.h
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/PartialRigidificationConstraint.inl
+    ${SOFTROBOTS_SOURCE_DIR}/component/constraint/PositionConstraint.h
+    ${SOFTROBOTS_SOURCE_DIR}/component/constraint/PositionConstraint.inl
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/SurfacePressureConstraint.h
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/SurfacePressureConstraint.inl
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/UnilateralPlaneConstraint.h
@@ -45,6 +47,8 @@ set(HEADER_FILES
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/AffineFunctionModel.inl
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/CableModel.h
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/CableModel.inl
+    ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/PositionModel.h
+    ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/PositionModel.inl
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/SurfacePressureModel.h
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/SurfacePressureModel.inl
 
@@ -77,10 +81,12 @@ set(SOURCE_FILES
 
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/CableConstraint.cpp
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/PartialRigidificationConstraint.cpp
+    ${SOFTROBOTS_SOURCE_DIR}/component/constraint/PositionConstraint.cpp
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/SurfacePressureConstraint.cpp
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/UnilateralPlaneConstraint.cpp
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/AffineFunctionModel.cpp
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/CableModel.cpp
+    ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/PositionModel.cpp
     ${SOFTROBOTS_SOURCE_DIR}/component/constraint/model/SurfacePressureModel.cpp
 
     ${SOFTROBOTS_SOURCE_DIR}/component/controller/AnimationEditor.cpp

--- a/docs/sofapython3/examples/component/constraint/PositionConstraint/PositionConstraint.py
+++ b/docs/sofapython3/examples/component/constraint/PositionConstraint/PositionConstraint.py
@@ -1,0 +1,24 @@
+def createScene(rootnode):
+
+    rootnode.addObject('FreeMotionAnimationLoop')
+    rootnode.addObject('GenericConstraintSolver', maxIterations=1e4, tolerance=1e-5, printLog=True)
+    rootnode.gravity = [0, -9.81, 0]
+    rootnode.addObject('VisualStyle', displayFlags='showForceFields')
+
+    body = rootnode.addChild('Body')
+    body.addObject('EulerImplicitSolver')
+    body.addObject('SparseLDLSolver')
+    body.addObject('RegularGridTopology', min=[0, 0, 0], max=[0.5, 1, 0.1], n=[5, 10, 2])
+    body.addObject('MechanicalObject')
+    body.addObject('UniformMass', totalMass=0.1)
+    body.addObject('TetrahedronFEMForceField', poissonRatio=0.3, youngModulus=1e3)
+    body.addObject('GenericConstraintCorrection')
+    body.addObject('BoxROI', name="boxToFixed", box=[0, 0, 0, 0.5, 0.1, 0.1], drawBoxes=True)
+    body.addObject('BoxROI', name="boxToPull", box=[0, 0.9, 0, 0.5, 1, 0.1], drawBoxes=True)
+    body.addObject('FixedConstraint', indices=body.boxToFixed.indices.linkpath)
+    body.addObject('PartialFixedConstraint', indices=body.boxToPull.indices.linkpath, fixedDirections=[1, 0, 1])
+    body.addObject('PositionConstraint', indices=body.boxToPull.indices.linkpath,
+                   valueType="displacement", value=0.5, useDirections=[0, 1, 0])
+
+
+

--- a/docs/sofapython3/examples/component/constraint/PositionConstraint/PositionConstraint.py
+++ b/docs/sofapython3/examples/component/constraint/PositionConstraint/PositionConstraint.py
@@ -1,5 +1,7 @@
 def createScene(rootnode):
 
+    rootnode.addObject('RequiredPlugin', name='SoftRobots')
+
     rootnode.addObject('FreeMotionAnimationLoop')
     rootnode.addObject('GenericConstraintSolver', maxIterations=1e4, tolerance=1e-5, printLog=True)
     rootnode.gravity = [0, -9.81, 0]

--- a/src/SoftRobots/component/constraint/PositionConstraint.cpp
+++ b/src/SoftRobots/component/constraint/PositionConstraint.cpp
@@ -114,11 +114,6 @@ void PositionForceConstraintResolution::resolution(int line, double** w, double*
 
 
 ////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
-
 int PositionConstraintClass = RegisterObject("Simulate a Position.")
 .add< PositionConstraint<Vec3Types> >(true)
 .add< PositionConstraint<Vec2Types> >()

--- a/src/SoftRobots/component/constraint/PositionConstraint.cpp
+++ b/src/SoftRobots/component/constraint/PositionConstraint.cpp
@@ -1,0 +1,140 @@
+/******************************************************************************
+*               SOFA, Simulation Open-Framework Architecture                  *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                           Plugin SoftRobots v1.0                            *
+*                                                                             *
+* This plugin is also distributed under the GNU LGPL (Lesser General          *
+* Public License) license with the same conditions than SOFA.                 *
+*                                                                             *
+* Contributors: Defrost team  (INRIA, University of Lille, CNRS,              *
+*               Ecole Centrale de Lille)                                      *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+*                                                                             *
+******************************************************************************/
+
+#define SOFTROBOTS_POSITIONCONSTRAINT_CPP
+#include <SoftRobots/component/constraint/PositionConstraint.inl>
+
+#include <sofa/core/ObjectFactory.h>
+
+namespace sofa::component::constraintset
+{
+
+//////////////////////////////////////PositionConstraintConstraintResolution1Dof/////////////////////////////////////////////
+using namespace sofa::defaulttype;
+using namespace sofa::helper;
+using namespace sofa::core;
+
+//----------- Displacement constraint --------------
+PositionDisplacementConstraintResolution::PositionDisplacementConstraintResolution(const double& imposedDisplacement, const double &min, const double &max)
+    : sofa::core::behavior::ConstraintResolution(1)
+    , m_imposedDisplacement(imposedDisplacement)
+    , m_minForce(min)
+    , m_maxForce(max)
+{ }
+
+
+void PositionDisplacementConstraintResolution::init(int line, double** w, double * lambda)
+{
+    SOFA_UNUSED(lambda);
+    m_wActuatorActuator = w[line][line];
+}
+
+
+void PositionDisplacementConstraintResolution::resolution(int line, double** w, double* d, double* lambda, double* dfree)
+{
+    SOFA_UNUSED(dfree);
+    SOFA_UNUSED(w);
+
+    // da=Waa*(lambda_a) + Sum Wai * lambda_i  = m_imposedDisplacement
+    lambda[line] -= (d[line]-m_imposedDisplacement) / m_wActuatorActuator;
+
+    if (lambda[line]<m_minForce)
+        lambda[line]=m_minForce;
+
+    if (lambda[line]>m_maxForce)
+        lambda[line]=m_maxForce;
+}
+
+
+//--------------- Force constraint -------------
+PositionForceConstraintResolution::PositionForceConstraintResolution(const double &imposedForce, const double& min, const double& max)
+    : ConstraintResolution(1)
+    , m_imposedForce(imposedForce)
+    , m_minDisplacement(min)
+    , m_maxDisplacement(max)
+{ }
+
+
+void PositionForceConstraintResolution::init(int line, double** w, double * lambda)
+{
+    SOFA_UNUSED(lambda);
+    m_wActuatorActuator = w[line][line];
+}
+
+void PositionForceConstraintResolution::resolution(int line, double** w, double* d, double* lambda, double* dfree)
+{
+    SOFA_UNUSED(dfree);
+    SOFA_UNUSED(w);
+
+    double displacement = m_wActuatorActuator*m_imposedForce + d[line];
+
+    if (displacement<m_minDisplacement)
+    {
+        displacement=m_minDisplacement;
+        lambda[line] -= (d[line]-displacement) / m_wActuatorActuator;
+    }
+    else if (displacement>m_maxDisplacement)
+    {
+        displacement=m_maxDisplacement;
+        lambda[line] -= (d[line]-displacement) / m_wActuatorActuator;
+    }
+    else
+        lambda[line] = m_imposedForce;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
+// Registering the component
+// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
+// 1-RegisterObject("description") + .add<> : Register the component
+// 2-.add<>(true) : Set default template
+
+int PositionConstraintClass = RegisterObject("Simulate a Position.")
+.add< PositionConstraint<Vec3Types> >(true)
+.add< PositionConstraint<Vec2Types> >()
+.add< PositionConstraint<Rigid3Types> >()
+
+;
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Force template specialization for the most common sofa type.
+// This goes with the extern template declaration in the .h. Declaring extern template
+// avoid the code generation of the template for each compilation unit.
+// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
+template class PositionConstraint<Vec3Types>;
+template class PositionConstraint<Vec2Types>;
+template class PositionConstraint<Rigid3Types>;
+
+
+} // namespace
+

--- a/src/SoftRobots/component/constraint/PositionConstraint.cpp
+++ b/src/SoftRobots/component/constraint/PositionConstraint.cpp
@@ -33,7 +33,7 @@
 
 #include <sofa/core/ObjectFactory.h>
 
-namespace softrobots::constraintset
+namespace softrobots::constraint
 {
 
 //////////////////////////////////////PositionConstraintConstraintResolution1Dof/////////////////////////////////////////////

--- a/src/SoftRobots/component/constraint/PositionConstraint.cpp
+++ b/src/SoftRobots/component/constraint/PositionConstraint.cpp
@@ -65,11 +65,7 @@ void PositionDisplacementConstraintResolution::resolution(int line, double** w, 
     // da=Waa*(lambda_a) + Sum Wai * lambda_i  = m_imposedDisplacement
     lambda[line] -= (d[line]-m_imposedDisplacement) / m_wActuatorActuator;
 
-    if (lambda[line]<m_minForce)
-        lambda[line]=m_minForce;
-
-    if (lambda[line]>m_maxForce)
-        lambda[line]=m_maxForce;
+    std::clamp(lambda[line], m_minForce, m_maxForce);
 }
 
 

--- a/src/SoftRobots/component/constraint/PositionConstraint.cpp
+++ b/src/SoftRobots/component/constraint/PositionConstraint.cpp
@@ -33,7 +33,7 @@
 
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa::component::constraintset
+namespace softrobots::constraintset
 {
 
 //////////////////////////////////////PositionConstraintConstraintResolution1Dof/////////////////////////////////////////////

--- a/src/SoftRobots/component/constraint/PositionConstraint.cpp
+++ b/src/SoftRobots/component/constraint/PositionConstraint.cpp
@@ -122,10 +122,6 @@ int PositionConstraintClass = RegisterObject("Simulate a Position.")
 ;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Force template specialization for the most common sofa type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 template class PositionConstraint<Vec3Types>;
 template class PositionConstraint<Vec2Types>;
 template class PositionConstraint<Rigid3Types>;

--- a/src/SoftRobots/component/constraint/PositionConstraint.h
+++ b/src/SoftRobots/component/constraint/PositionConstraint.h
@@ -34,13 +34,7 @@
 
 #include <SoftRobots/component/constraint/model/PositionModel.h>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace constraintset
+namespace softrobots::constraintset
 {
 using sofa::type::Vec;
 using sofa::type::Vec3d;
@@ -106,11 +100,11 @@ public:
     typedef typename DataTypes::Real Real;
 
     typedef typename DataTypes::MatrixDeriv MatrixDeriv;
-    typedef typename core::behavior::MechanicalState<DataTypes> MechanicalState;
+    typedef typename sofa::core::behavior::MechanicalState<DataTypes> MechanicalState;
 
-    typedef Data<VecCoord>		DataVecCoord;
-    typedef Data<VecDeriv>		DataVecDeriv;
-    typedef Data<MatrixDeriv>    DataMatrixDeriv;
+    typedef sofa::Data<VecCoord>		DataVecCoord;
+    typedef sofa::Data<VecDeriv>		DataVecDeriv;
+    typedef sofa::Data<MatrixDeriv>    DataMatrixDeriv;
 
 public:
     PositionConstraint(MechanicalState* object = nullptr);
@@ -126,12 +120,12 @@ public:
                                 BaseVector *resV,
                                 const BaseVector *Jdx) override;
 
-    void getConstraintResolution(const core::ConstraintParams *cParam,
+    void getConstraintResolution(const sofa::core::ConstraintParams *cParam,
                                  std::vector<ConstraintResolution*>& resTab,
                                  unsigned int& offset) override;
 
     void storeLambda(const ConstraintParams* cParams,
-                     core::MultiVecDerivId res,
+                     sofa::core::MultiVecDerivId res,
                      const BaseVector* lambda) override;
     ////////////////////////////////////////////////////////////////
 
@@ -148,20 +142,20 @@ public:
 
 protected:
     //Input data
-    Data<double>                d_force; ///< force applied on the points
-    Data<double>                d_displacement; ///< displacement of the points
+    sofa::Data<double>                d_force; ///< force applied on the points
+    sofa::Data<double>                d_displacement; ///< displacement of the points
 
-    Data<Real>                  d_maxForce; ///< maximum force applied on the points
-    Data<Real>                  d_minForce; ///< minimum force applied on the points
+    sofa::Data<Real>                  d_maxForce; ///< maximum force applied on the points
+    sofa::Data<Real>                  d_minForce; ///< minimum force applied on the points
 
-    Data<Real>                  d_maxPositiveDisplacement; ///< maximum displacement of the points in the positive direction
-    Data<Real>                  d_maxNegativeDisplacement; ///< maximum displacement of the points in the negative direction
+    sofa::Data<Real>                  d_maxPositiveDisplacement; ///< maximum displacement of the points in the positive direction
+    sofa::Data<Real>                  d_maxNegativeDisplacement; ///< maximum displacement of the points in the negative direction
 
-    Data<type::vector< Real > >       d_value;
-    Data<unsigned int>                d_valueIndex;
-    Data<helper::OptionsGroup>        d_valueType;
-                                     // displacement = the constraint will impose the displacement provided in data d_inputValue[d_iputIndex]
-                                     // force = the constraint will impose the force provided in data d_inputValue[d_iputIndex]
+    sofa::Data<sofa::type::vector< Real > > d_value;
+    sofa::Data<unsigned int>                d_valueIndex;
+    sofa::Data<sofa::helper::OptionsGroup>  d_valueType;
+                                            // displacement = the constraint will impose the displacement provided in data d_inputValue[d_iputIndex]
+                                            // force = the constraint will impose the force provided in data d_inputValue[d_iputIndex]
 
     VecCoord                    m_x0;
 
@@ -179,9 +173,5 @@ extern template class PositionConstraint<sofa::defaulttype::Rigid3Types>;
 #endif
 
 
-} // namespace constraintset
-
-} // namespace component
-
-} // namespace sofa
+} // namespace
 

--- a/src/SoftRobots/component/constraint/PositionConstraint.h
+++ b/src/SoftRobots/component/constraint/PositionConstraint.h
@@ -34,7 +34,7 @@
 
 #include <SoftRobots/component/constraint/model/PositionModel.h>
 
-namespace softrobots::constraintset
+namespace softrobots::constraint
 {
 using sofa::type::Vec;
 using sofa::type::Vec3d;

--- a/src/SoftRobots/component/constraint/PositionConstraint.h
+++ b/src/SoftRobots/component/constraint/PositionConstraint.h
@@ -1,0 +1,198 @@
+/******************************************************************************
+*               SOFA, Simulation Open-Framework Architecture                  *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                           Plugin SoftRobots v1.0                            *
+*                                                                             *
+* This plugin is also distributed under the GNU LGPL (Lesser General          *
+* Public License) license with the same conditions than SOFA.                 *
+*                                                                             *
+* Contributors: Defrost team  (INRIA, University of Lille, CNRS,              *
+*               Ecole Centrale de Lille)                                      *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+*                                                                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/helper/OptionsGroup.h>
+#include <sofa/core/behavior/ConstraintResolution.h>
+
+#include <SoftRobots/component/constraint/model/PositionModel.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace constraintset
+{
+using sofa::type::Vec;
+using sofa::type::Vec3d;
+using sofa::helper::WriteAccessor;
+using sofa::type::vector;
+using sofa::core::ConstraintParams;
+using sofa::linearalgebra::BaseVector;
+using sofa::core::visual::VisualParams ;
+using sofa::core::behavior::ConstraintResolution;
+
+
+class PositionDisplacementConstraintResolution : public ConstraintResolution
+{
+public:
+    PositionDisplacementConstraintResolution(const double &imposedDisplacement, const double& min, const double& max);
+
+    //////////////////// Inherited from ConstraintResolution ////////////////////
+    void init(int line, double** w, double *lambda) override;
+    void resolution(int line, double** w, double* d, double* lambda, double* dfree) override;
+    /////////////////////////////////////////////////////////////////////////////
+
+protected:
+
+    double      m_wActuatorActuator;
+    double      m_imposedDisplacement;
+    double      m_minForce;
+    double      m_maxForce;
+
+};
+
+class PositionForceConstraintResolution : public ConstraintResolution
+{
+public:
+    PositionForceConstraintResolution(const double& imposedForce, const double& min, const double& max);
+
+    //////////////////// Inherited from ConstraintResolution ////////////////////
+    void init(int line, double** w, double *force) override;
+    void resolution(int line, double** w, double* d, double* force, double* dfree) override;
+    /////////////////////////////////////////////////////////////////////////////
+
+protected:
+
+    double      m_wActuatorActuator;
+    double      m_imposedForce;
+    double      m_minDisplacement;
+    double      m_maxDisplacement;
+
+};
+
+
+
+
+/**
+ * This component simulates a force exerted by a cable to solve an effector constraint.
+ * Description can be found at:
+ * https://softrobotscomponents.readthedocs.io
+*/
+template< class DataTypes >
+class PositionConstraint : public PositionModel<DataTypes>
+{
+public:
+    SOFA_CLASS(SOFA_TEMPLATE(PositionConstraint,DataTypes), SOFA_TEMPLATE(PositionModel,DataTypes));
+
+    typedef typename DataTypes::Coord Coord;
+    typedef typename DataTypes::Deriv Deriv;
+    typedef typename DataTypes::VecCoord VecCoord;
+    typedef typename DataTypes::VecDeriv VecDeriv;
+    typedef typename DataTypes::Real Real;
+
+    typedef typename DataTypes::MatrixDeriv MatrixDeriv;
+    typedef typename core::behavior::MechanicalState<DataTypes> MechanicalState;
+
+    typedef Data<VecCoord>		DataVecCoord;
+    typedef Data<VecDeriv>		DataVecDeriv;
+    typedef Data<MatrixDeriv>    DataMatrixDeriv;
+
+public:
+    PositionConstraint(MechanicalState* object = nullptr);
+    ~PositionConstraint() override;
+
+    /////////////// Inherited from BaseObject //////////////////////
+    void init() override;
+    void reinit() override;
+    ///////////////////////////////////////////////////////////////
+
+    /////////////////// Inherited from BaseConstraint ///////////////
+    void getConstraintViolation(const ConstraintParams* cParams ,
+                                BaseVector *resV,
+                                const BaseVector *Jdx) override;
+
+    void getConstraintResolution(const core::ConstraintParams *cParam,
+                                 std::vector<ConstraintResolution*>& resTab,
+                                 unsigned int& offset) override;
+
+    void storeLambda(const ConstraintParams* cParams,
+                     core::MultiVecDerivId res,
+                     const BaseVector* lambda) override;
+    ////////////////////////////////////////////////////////////////
+
+
+    ////////////////////////// Inherited attributes ////////////////////////////
+    /// https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
+    /// Bring inherited attributes and function in the current lookup context.
+    /// otherwise any access to the base::attribute would require
+    /// the "this->" approach.
+    using PositionModel<DataTypes>::d_indices ;
+    using PositionModel<DataTypes>::d_componentState ;
+    using PositionModel<DataTypes>::d_useDirections ;
+    using PositionModel<DataTypes>::d_directions ;
+    using PositionModel<DataTypes>::d_weight ;
+    using PositionModel<DataTypes>::m_constraintId ;
+    using PositionModel<DataTypes>::m_state ;
+    ///////////////////////////////////////////////////////////////////////////
+
+protected:
+    //Input data
+    Data<double>                d_force; ///< force applied on the points
+    Data<double>                d_displacement; ///< displacement of the points
+
+    Data<Real>                  d_maxForce; ///< maximum force applied on the points
+    Data<Real>                  d_minForce; ///< minimum force applied on the points
+
+    Data<Real>                  d_maxPositiveDisplacement; ///< maximum displacement of the points in the positive direction
+    Data<Real>                  d_maxNegativeDisplacement; ///< maximum displacement of the points in the negative direction
+
+    Data<type::vector< Real > >       d_value;
+    Data<unsigned int>                d_valueIndex;
+    Data<helper::OptionsGroup>        d_valueType;
+                                     // displacement = the constraint will impose the displacement provided in data d_inputValue[d_iputIndex]
+                                     // force = the constraint will impose the force provided in data d_inputValue[d_iputIndex]
+
+    VecCoord                    m_x0;
+
+    void internalInit();
+
+private:
+    void setUpDisplacementLimits(double& imposedValue, double& minForce, double& maxForce);
+    void setUpForceLimits(double& imposedValue, double& minDisplacement, double& maxDisplacement);
+};
+
+// Declares template as extern to avoid the code generation of the template for
+// each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
+#if !defined(SOFTROBOTS_POSITIONCONSTRAINT_CPP)
+extern template class PositionConstraint<sofa::defaulttype::Vec3Types>;
+extern template class PositionConstraint<sofa::defaulttype::Vec2Types>;
+extern template class PositionConstraint<sofa::defaulttype::Rigid3Types>;
+#endif
+
+
+} // namespace constraintset
+
+} // namespace component
+
+} // namespace sofa
+

--- a/src/SoftRobots/component/constraint/PositionConstraint.h
+++ b/src/SoftRobots/component/constraint/PositionConstraint.h
@@ -137,10 +137,6 @@ public:
 
 
     ////////////////////////// Inherited attributes ////////////////////////////
-    /// https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
-    /// Bring inherited attributes and function in the current lookup context.
-    /// otherwise any access to the base::attribute would require
-    /// the "this->" approach.
     using PositionModel<DataTypes>::d_indices ;
     using PositionModel<DataTypes>::d_componentState ;
     using PositionModel<DataTypes>::d_useDirections ;

--- a/src/SoftRobots/component/constraint/PositionConstraint.h
+++ b/src/SoftRobots/component/constraint/PositionConstraint.h
@@ -181,8 +181,6 @@ private:
     void setUpForceLimits(double& imposedValue, double& minDisplacement, double& maxDisplacement);
 };
 
-// Declares template as extern to avoid the code generation of the template for
-// each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 #if !defined(SOFTROBOTS_POSITIONCONSTRAINT_CPP)
 extern template class PositionConstraint<sofa::defaulttype::Vec3Types>;
 extern template class PositionConstraint<sofa::defaulttype::Vec2Types>;

--- a/src/SoftRobots/component/constraint/PositionConstraint.h
+++ b/src/SoftRobots/component/constraint/PositionConstraint.h
@@ -93,11 +93,6 @@ protected:
 
 
 
-/**
- * This component simulates a force exerted by a cable to solve an effector constraint.
- * Description can be found at:
- * https://softrobotscomponents.readthedocs.io
-*/
 template< class DataTypes >
 class PositionConstraint : public PositionModel<DataTypes>
 {

--- a/src/SoftRobots/component/constraint/PositionConstraint.inl
+++ b/src/SoftRobots/component/constraint/PositionConstraint.inl
@@ -33,13 +33,7 @@
 
 using sofa::helper::OptionsGroup;
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace constraintset
+namespace softrobots::constraintset
 {
 
 using sofa::core::objectmodel::ComponentState;
@@ -102,7 +96,7 @@ void PositionConstraint<DataTypes>::init()
 
     internalInit();
 
-    ReadAccessor<Data<VecCoord> > x = m_state->readPositions();
+    ReadAccessor<sofa::Data<VecCoord> > x = m_state->readPositions();
     m_x0 = x;
 }
 
@@ -117,7 +111,7 @@ void PositionConstraint<DataTypes>::internalInit()
 {
     if(d_value.getValue().size()==0)
     {
-        WriteAccessor<Data<vector<Real>>> value = d_value;
+        WriteAccessor<sofa::Data<vector<Real>>> value = d_value;
         value.resize(1);
     }
 
@@ -139,8 +133,8 @@ void PositionConstraint<DataTypes>::getConstraintViolation(const ConstraintParam
 
     SOFA_UNUSED(cParams);
 
-    ReadAccessor<Data<VecCoord>> x = m_state->readPositions() ;
-    ReadAccessor<Data<type::vector<sofa::Index>> > indices = d_indices;
+    ReadAccessor<sofa::Data<VecCoord>> x = m_state->readPositions() ;
+    ReadAccessor<sofa::Data<sofa::type::vector<sofa::Index>> > indices = d_indices;
     sofa::Index sizeIndices = d_indices.getValue().size();
 
     int index = 0;
@@ -151,7 +145,7 @@ void PositionConstraint<DataTypes>::getConstraintViolation(const ConstraintParam
 
         Deriv d = DataTypes::coordDifference(pos, pos0);
 
-        for(Size j=0; j<DataTypes::Deriv::total_size; j++)
+        for(sofa::Size j=0; j<DataTypes::Deriv::total_size; j++)
             if(d_useDirections.getValue()[j])
             {
                 Real dfree = Jdx->element(index) + d*d_directions.getValue()[j]*d_weight.getValue();
@@ -200,7 +194,7 @@ void PositionConstraint<DataTypes>::getConstraintResolution(const ConstraintPara
 
 template<class DataTypes>
 void PositionConstraint<DataTypes>::storeLambda(const ConstraintParams* cParams,
-                                                core::MultiVecDerivId res,
+                                                sofa::core::MultiVecDerivId res,
                                                 const sofa::linearalgebra::BaseVector* lambda)
 {
     SOFA_UNUSED(res);
@@ -244,9 +238,5 @@ void PositionConstraint<DataTypes>::setUpForceLimits(double& imposedValue, doubl
 }
 
 
-} // namespace constraintset
-
-} // namespace component
-
-} // namespace sofa
+} // namespace
 

--- a/src/SoftRobots/component/constraint/PositionConstraint.inl
+++ b/src/SoftRobots/component/constraint/PositionConstraint.inl
@@ -81,7 +81,7 @@ PositionConstraint<DataTypes>::PositionConstraint(MechanicalState* object)
 
     , d_valueType(initData(&d_valueType, OptionsGroup(2,"displacement","force"), "valueType",
                                           "displacement = the constraint will impose the displacement provided in data value[valueIndex] \n"
-                                          "force = the contstraint will impose the force provided in data value[valueIndex] \n"
+                                          "force = the constraint will impose the force provided in data value[valueIndex] \n"
                                           "If unspecified, the default value is displacement"))
 {
     d_force.setGroup("Vector");

--- a/src/SoftRobots/component/constraint/PositionConstraint.inl
+++ b/src/SoftRobots/component/constraint/PositionConstraint.inl
@@ -134,8 +134,11 @@ void PositionConstraint<DataTypes>::getConstraintViolation(const ConstraintParam
     SOFA_UNUSED(cParams);
 
     ReadAccessor<sofa::Data<VecCoord>> x = m_state->readPositions() ;
-    ReadAccessor<sofa::Data<sofa::type::vector<sofa::Index>> > indices = d_indices;
-    sofa::Index sizeIndices = d_indices.getValue().size();
+    const auto& useDirections = sofa::helper::getReadAccessor(d_useDirections);
+    const auto& directions = sofa::helper::getReadAccessor(d_directions);
+    const auto& weight = sofa::helper::getReadAccessor(d_weight);
+    const auto& indices = sofa::helper::getReadAccessor(d_indices);
+    sofa::Index sizeIndices = indices.size();
 
     int index = 0;
     for (unsigned int i=0; i<sizeIndices; i++)
@@ -146,9 +149,9 @@ void PositionConstraint<DataTypes>::getConstraintViolation(const ConstraintParam
         Deriv d = DataTypes::coordDifference(pos, pos0);
 
         for(sofa::Size j=0; j<DataTypes::Deriv::total_size; j++)
-            if(d_useDirections.getValue()[j])
+            if(useDirections[j])
             {
-                Real dfree = Jdx->element(index) + d*d_directions.getValue()[j]*d_weight.getValue();
+                Real dfree = Jdx->element(index) + d*directions[j]*weight;
                 resV->set(m_constraintId+index, dfree);
                 index++;
             }

--- a/src/SoftRobots/component/constraint/PositionConstraint.inl
+++ b/src/SoftRobots/component/constraint/PositionConstraint.inl
@@ -1,0 +1,252 @@
+/******************************************************************************
+*               SOFA, Simulation Open-Framework Architecture                  *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                           Plugin SoftRobots v1.0                            *
+*                                                                             *
+* This plugin is also distributed under the GNU LGPL (Lesser General          *
+* Public License) license with the same conditions than SOFA.                 *
+*                                                                             *
+* Contributors: Defrost team  (INRIA, University of Lille, CNRS,              *
+*               Ecole Centrale de Lille)                                      *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+*                                                                             *
+******************************************************************************/
+#pragma once
+
+#include <SoftRobots/component/constraint/PositionConstraint.h>
+
+using sofa::helper::OptionsGroup;
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace constraintset
+{
+
+using sofa::core::objectmodel::ComponentState;
+using sofa::helper::WriteAccessor;
+using sofa::helper::ReadAccessor;
+
+template<class DataTypes>
+PositionConstraint<DataTypes>::PositionConstraint(MechanicalState* object)
+    : PositionModel<DataTypes>(object)
+
+    , d_force(initData(&d_force,double(0.0), "force",
+                                         "Output force. Warning: to get the actual force you should divide this value by dt."))
+
+    , d_displacement(initData(&d_displacement,double(0.0), "displacement",
+                          "Output displacement compared to the initial position."))
+
+    , d_maxForce(initData(&d_maxForce, "maxForce",
+                          "Maximum force allowed. \n"
+                          "If unspecified no maximum value will be considered."))
+
+    , d_minForce(initData(&d_minForce, "minForce",
+                          "Minimum force allowed. \n"
+                          "If unspecified no minimum value will be considered."))
+
+    , d_maxPositiveDisplacement(initData(&d_maxPositiveDisplacement,"maxPositiveDisp",
+                                         "Maximum displacement in the positive direction. \n"
+                                         "If unspecified no maximum value will be considered."))
+
+    , d_maxNegativeDisplacement(initData(&d_maxNegativeDisplacement,"maxNegativeDisp",
+                                         "Maximum displacement in the negative direction. \n"
+                                         "If unspecified no maximum value will be considered."))
+
+    , d_value(initData(&d_value, "value",
+                                "Displacement or force to impose.\n"))
+
+    , d_valueIndex(initData(&d_valueIndex, (unsigned int) 0, "valueIndex",
+                                  "Index of the value (in InputValue vector) that we want to impose \n"
+                                  "If unspecified the default value is {0}"))
+
+    , d_valueType(initData(&d_valueType, OptionsGroup(2,"displacement","force"), "valueType",
+                                          "displacement = the contstraint will impose the displacement provided in data value[valueIndex] \n"
+                                          "force = the contstraint will impose the force provided in data value[valueIndex] \n"
+                                          "If unspecified, the default value is displacement"))
+{
+    d_force.setGroup("Vector");
+    d_displacement.setGroup("Vector");
+    d_force.setReadOnly(true);
+    d_displacement.setReadOnly(true);
+}
+
+template<class DataTypes>
+PositionConstraint<DataTypes>::~PositionConstraint()
+{
+}
+
+template<class DataTypes>
+void PositionConstraint<DataTypes>::init()
+{
+    Inherit1::init();
+
+    internalInit();
+
+    ReadAccessor<Data<VecCoord> > x = m_state->readPositions();
+    m_x0 = x;
+}
+
+template<class DataTypes>
+void PositionConstraint<DataTypes>::reinit()
+{
+    internalInit();
+}
+
+template<class DataTypes>
+void PositionConstraint<DataTypes>::internalInit()
+{
+    if(d_value.getValue().size()==0)
+    {
+        WriteAccessor<Data<vector<Real>>> value = d_value;
+        value.resize(1);
+    }
+
+    // check for errors in the initialization
+    if(d_value.getValue().size()<d_valueIndex.getValue())
+    {
+        msg_warning() << "Bad size for data value (size="<< d_value.getValue().size()<<"), or wrong value for data valueIndex (valueIndex="<<d_valueIndex.getValue()<<"). Set default valueIndex=0.";
+        d_valueIndex.setValue(0);
+    }
+}
+
+template<class DataTypes>
+void PositionConstraint<DataTypes>::getConstraintViolation(const ConstraintParams* cParams,
+                                                         BaseVector *resV,
+                                                         const BaseVector *Jdx)
+{
+    if(d_componentState.getValue() != ComponentState::Valid)
+        return;
+
+    SOFA_UNUSED(cParams);
+
+    ReadAccessor<Data<VecCoord>> x = m_state->readPositions() ;
+    ReadAccessor<Data<type::vector<sofa::Index>> > indices = d_indices;
+    sofa::Index sizeIndices = d_indices.getValue().size();
+
+    int index = 0;
+    for (unsigned int i=0; i<sizeIndices; i++)
+    {
+        Coord pos = x[indices[i]];
+        Coord pos0 = m_x0[indices[i]];
+
+        Deriv d = DataTypes::coordDifference(pos, pos0);
+
+        for(Size j=0; j<DataTypes::Deriv::total_size; j++)
+            if(d_useDirections.getValue()[j])
+            {
+                Real dfree = Jdx->element(index) + d*d_directions.getValue()[j]*d_weight.getValue();
+                resV->set(m_constraintId+index, dfree);
+                index++;
+            }
+    }
+}
+
+template<class DataTypes>
+void PositionConstraint<DataTypes>::getConstraintResolution(const ConstraintParams* cParam,
+                                                         std::vector<ConstraintResolution*>& resTab,
+                                                         unsigned int& offset)
+{
+    if(d_componentState.getValue() != ComponentState::Valid)
+            return ;
+
+    SOFA_UNUSED(cParam);
+
+    double imposedValue=d_value.getValue()[d_valueIndex.getValue()];
+    sofa::Size nbIndices = d_indices.getValue().size();
+
+    if(d_valueType.getValue().getSelectedItem() == "displacement") // displacement
+    {
+        double maxForce = std::numeric_limits<double>::max();
+        double minForce = -maxForce;
+        setUpDisplacementLimits(imposedValue,minForce,maxForce);
+
+        for (sofa::Size i=0; i<nbIndices; i++){
+            PositionDisplacementConstraintResolution *cr=  new PositionDisplacementConstraintResolution(imposedValue, minForce, maxForce);
+            resTab[offset++] = cr;
+        }
+    }
+    else // force
+    {
+        double maxDisplacement = std::numeric_limits<double>::max();
+        double minDisplacement = -maxDisplacement;
+        setUpForceLimits(imposedValue,minDisplacement,maxDisplacement);
+
+        for (sofa::Size i=0; i<nbIndices; i++){
+            PositionForceConstraintResolution *cr=  new PositionForceConstraintResolution(imposedValue, minDisplacement, maxDisplacement);
+            resTab[offset++] = cr;
+        }
+    }
+}
+
+template<class DataTypes>
+void PositionConstraint<DataTypes>::storeLambda(const ConstraintParams* cParams,
+                                                core::MultiVecDerivId res,
+                                                const sofa::linearalgebra::BaseVector* lambda)
+{
+    SOFA_UNUSED(res);
+    SOFA_UNUSED(cParams);
+
+    if(d_componentState.getValue() != ComponentState::Valid)
+        return ;
+
+    d_force.setValue(lambda->element(m_constraintId));
+}
+
+
+template<class DataTypes>
+void PositionConstraint<DataTypes>::setUpDisplacementLimits(double& imposedValue, double& minForce, double& maxForce)
+{
+    if(d_maxPositiveDisplacement.isSet() && imposedValue>d_maxPositiveDisplacement.getValue())
+        imposedValue = d_maxPositiveDisplacement.getValue();
+
+    if(d_maxNegativeDisplacement.isSet() && imposedValue<-d_maxNegativeDisplacement.getValue())
+        imposedValue = -d_maxNegativeDisplacement.getValue();
+
+    if(d_minForce.isSet())
+        minForce=d_minForce.getValue();
+    if(d_maxForce.isSet())
+        maxForce=d_maxForce.getValue();
+}
+
+template<class DataTypes>
+void PositionConstraint<DataTypes>::setUpForceLimits(double& imposedValue, double& minDisplacement, double& maxDisplacement)
+{
+    if(d_maxForce.isSet() && imposedValue>d_maxForce.getValue())
+        imposedValue = d_maxForce.getValue();
+
+    if(d_minForce.isSet() && imposedValue<d_minForce.getValue())
+        imposedValue = d_minForce.getValue();
+
+    if(d_maxNegativeDisplacement.isSet())
+        minDisplacement=-d_maxNegativeDisplacement.getValue();
+    if(d_maxPositiveDisplacement.isSet())
+        maxDisplacement=d_maxPositiveDisplacement.getValue();
+}
+
+
+} // namespace constraintset
+
+} // namespace component
+
+} // namespace sofa
+

--- a/src/SoftRobots/component/constraint/PositionConstraint.inl
+++ b/src/SoftRobots/component/constraint/PositionConstraint.inl
@@ -33,7 +33,7 @@
 
 using sofa::helper::OptionsGroup;
 
-namespace softrobots::constraintset
+namespace softrobots::constraint
 {
 
 using sofa::core::objectmodel::ComponentState;

--- a/src/SoftRobots/component/constraint/PositionConstraint.inl
+++ b/src/SoftRobots/component/constraint/PositionConstraint.inl
@@ -80,7 +80,7 @@ PositionConstraint<DataTypes>::PositionConstraint(MechanicalState* object)
                                   "If unspecified the default value is {0}"))
 
     , d_valueType(initData(&d_valueType, OptionsGroup(2,"displacement","force"), "valueType",
-                                          "displacement = the contstraint will impose the displacement provided in data value[valueIndex] \n"
+                                          "displacement = the constraint will impose the displacement provided in data value[valueIndex] \n"
                                           "force = the contstraint will impose the force provided in data value[valueIndex] \n"
                                           "If unspecified, the default value is displacement"))
 {

--- a/src/SoftRobots/component/constraint/model/PositionModel.cpp
+++ b/src/SoftRobots/component/constraint/model/PositionModel.cpp
@@ -31,7 +31,7 @@
 #include <SoftRobots/component/constraint/model/PositionModel.inl>
 #include <sofa/core/ObjectFactory.h>
 
-namespace softrobots::constraintset
+namespace softrobots::constraint
 {
 
 using namespace sofa::defaulttype;

--- a/src/SoftRobots/component/constraint/model/PositionModel.cpp
+++ b/src/SoftRobots/component/constraint/model/PositionModel.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
-*       SOFA, Simulation Open-Framework Architecture, version 1.0 RC 1        *
-*                (c) 2006-2011 MGH, INRIA, USTL, UJF, CNRS                    *
+*               SOFA, Simulation Open-Framework Architecture                  *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This library is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU Lesser General Public License as published by    *
@@ -16,13 +16,16 @@
 * along with this library; if not, write to the Free Software Foundation,     *
 * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
 *******************************************************************************
-*                               SOFA :: Modules                               *
+*                           Plugin SoftRobots v1.0                            *
 *                                                                             *
-* This component is not open-source                                           *
+* This plugin is also distributed under the GNU LGPL (Lesser General          *
+* Public License) license with the same conditions than SOFA.                 *
 *                                                                             *
-* Authors: Christian Duriez                                                   *
+* Contributors: Defrost team  (INRIA, University of Lille, CNRS,              *
+*               Ecole Centrale de Lille)                                      *
 *                                                                             *
-* Contact information: contact@sofa-framework.org                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+*                                                                             *
 ******************************************************************************/
 #define SOFTROBOTS_POSITIONMODEL_CPP
 #include <SoftRobots/component/constraint/model/PositionModel.inl>

--- a/src/SoftRobots/component/constraint/model/PositionModel.cpp
+++ b/src/SoftRobots/component/constraint/model/PositionModel.cpp
@@ -1,0 +1,95 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, version 1.0 RC 1        *
+*                (c) 2006-2011 MGH, INRIA, USTL, UJF, CNRS                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                               SOFA :: Modules                               *
+*                                                                             *
+* This component is not open-source                                           *
+*                                                                             *
+* Authors: Christian Duriez                                                   *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define SOFTROBOTS_POSITIONMODEL_CPP
+#include <SoftRobots/component/constraint/model/PositionModel.inl>
+#include <sofa/core/ObjectFactory.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace constraintset
+{
+
+using namespace sofa::defaulttype;
+using core::ConstraintParams;
+
+
+template<>
+void PositionModel<Rigid3Types>::normalizeDirections()
+{
+    VecDeriv directions;
+    directions.resize(6);
+    for(unsigned int i=0; i<6; i++)
+    {
+        directions[i] = d_directions.getValue()[i];
+        Vec<3, Real> vector1 = Vec<3, Real>(directions[i][0],directions[i][1],directions[i][2]);
+        Vec<3, Real> vector2 = Vec<3, Real>(directions[i][3],directions[i][4],directions[i][5]);
+        vector1.normalize();
+        vector2.normalize();
+        directions[i] = Deriv(vector1,vector2);
+    }
+    d_directions.setValue(directions);
+}
+
+template<>
+void PositionModel<Vec3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  RGBAColor& color) {
+    vparams->drawTool()->drawPoints(points, size, color);
+}
+
+template<>
+void PositionModel<Vec2Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  RGBAColor& color) {
+    vector<Vec3> pointsVec3;
+    for (auto point: points)
+        pointsVec3.push_back(Vec3(point[0], point[1], 0.));
+    vparams->drawTool()->drawPoints(pointsVec3, size, color);
+}
+
+template<>
+void PositionModel<Rigid3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  RGBAColor& color) {
+    vector<Vec3> pointsVec3;
+    for (auto point: points)
+        pointsVec3.push_back(point.getCenter());
+    vparams->drawTool()->drawPoints(pointsVec3, size, color);
+}
+
+// Force template specialization for the most common sofa type.
+// This goes with the extern template declaration in the .h. Declaring extern template
+// avoid the code generation of the template for each compilation unit.
+// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
+using namespace sofa::defaulttype;
+template class PositionModel<Vec3Types>;
+template class PositionModel<Rigid3Types>;
+template class PositionModel<Vec2Types>;
+
+} // namespace constraintset
+
+} // namespace component
+
+} // namespace sofa

--- a/src/SoftRobots/component/constraint/model/PositionModel.cpp
+++ b/src/SoftRobots/component/constraint/model/PositionModel.cpp
@@ -52,8 +52,8 @@ void PositionModel<Rigid3Types>::normalizeDirections()
     for(unsigned int i=0; i<6; i++)
     {
         directions[i] = d_directions.getValue()[i];
-        Vec<3, Real> vector1 = Vec<3, Real>(directions[i][0],directions[i][1],directions[i][2]);
-        Vec<3, Real> vector2 = Vec<3, Real>(directions[i][3],directions[i][4],directions[i][5]);
+        Vec<3, Real> vector1 {directions[i][0],directions[i][1],directions[i][2]};
+        Vec<3, Real> vector2 {directions[i][3],directions[i][4],directions[i][5]};
         vector1.normalize();
         vector2.normalize();
         directions[i] = Deriv(vector1,vector2);

--- a/src/SoftRobots/component/constraint/model/PositionModel.cpp
+++ b/src/SoftRobots/component/constraint/model/PositionModel.cpp
@@ -79,10 +79,6 @@ void PositionModel<Rigid3Types>::drawPoints(const VisualParams* vparams, const s
     vparams->drawTool()->drawPoints(pointsVec3, size, color);
 }
 
-// Force template specialization for the most common sofa type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 using namespace sofa::defaulttype;
 template class PositionModel<Vec3Types>;
 template class PositionModel<Rigid3Types>;

--- a/src/SoftRobots/component/constraint/model/PositionModel.cpp
+++ b/src/SoftRobots/component/constraint/model/PositionModel.cpp
@@ -31,17 +31,11 @@
 #include <SoftRobots/component/constraint/model/PositionModel.inl>
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace constraintset
+namespace softrobots::constraintset
 {
 
 using namespace sofa::defaulttype;
-using core::ConstraintParams;
+using sofa::core::ConstraintParams;
 
 
 template<>
@@ -87,8 +81,4 @@ template class PositionModel<Vec3Types>;
 template class PositionModel<Rigid3Types>;
 template class PositionModel<Vec2Types>;
 
-} // namespace constraintset
-
-} // namespace component
-
-} // namespace sofa
+} // namespace

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -31,7 +31,7 @@
 
 #include <SoftRobots/component/behavior/SoftRobotsConstraint.h>
 
-namespace softrobots::constraintset
+namespace softrobots::constraint
 {
 
 using sofa::core::behavior::SoftRobotsConstraint ;

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -31,14 +31,9 @@
 
 #include <SoftRobots/component/behavior/SoftRobotsConstraint.h>
 
-namespace sofa
+namespace softrobots::constraintset
 {
 
-namespace component
-{
-
-namespace constraintset
-{
 using sofa::core::behavior::SoftRobotsConstraint ;
 using sofa::core::ConstraintParams ;
 using sofa::linearalgebra::BaseVector ;
@@ -61,12 +56,12 @@ public:
     typedef typename DataTypes::Deriv               Deriv;
     typedef typename DataTypes::MatrixDeriv         MatrixDeriv;
     typedef typename Coord::value_type              Real;
-    typedef typename core::behavior::MechanicalState<DataTypes> MechanicalState;
+    typedef typename sofa::core::behavior::MechanicalState<DataTypes> MechanicalState;
 
     typedef typename DataTypes::MatrixDeriv::RowIterator MatrixDerivRowIterator;
-    typedef Data<VecCoord>                          DataVecCoord;
-    typedef Data<VecDeriv>                          DataVecDeriv;
-    typedef Data<MatrixDeriv>                       DataMatrixDeriv;
+    typedef sofa::Data<VecCoord>                          DataVecCoord;
+    typedef sofa::Data<VecDeriv>                          DataVecDeriv;
+    typedef sofa::Data<MatrixDeriv>                       DataMatrixDeriv;
 
 public:
     PositionModel(MechanicalState* object = nullptr);
@@ -87,15 +82,15 @@ public:
 
 
     /////////////// Inherited from BaseSoftRobotsConstraint ////////////////
-    void storeResults(type::vector<double> &delta) override;
+    void storeResults(sofa::type::vector<double> &delta) override;
     ///////////////////////////////////////////////////////////////////////////
 
 protected:
-    Data<type::vector<unsigned int> >             d_indices;
-    Data<Real>                                  d_weight;
-    Data<VecDeriv>                                d_directions;
-    Data<Vec<Deriv::total_size, bool>>             d_useDirections;
-    Data<type::vector<Real>>                    d_delta;
+    sofa::Data<sofa::type::vector<unsigned int> >     d_indices;
+    sofa::Data<Real>                                  d_weight;
+    sofa::Data<VecDeriv>                              d_directions;
+    sofa::Data<Vec<Deriv::total_size, bool>>          d_useDirections;
+    sofa::Data<sofa::type::vector<Real>>              d_delta;
 
     ////////////////////////// Inherited attributes ////////////////////////////
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
@@ -107,7 +102,7 @@ protected:
     void setDefaultDirections();
     void setDefaultUseDirections();
     void normalizeDirections();
-    void drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color) ;
+    void drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  sofa::type::RGBAColor& color) ;
 
 private:
     void internalInit();
@@ -120,16 +115,16 @@ private:
 
 
 template<> SOFA_SOFTROBOTS_API
-void PositionModel<defaulttype::Rigid3Types>::normalizeDirections();
+void PositionModel<sofa::defaulttype::Rigid3Types>::normalizeDirections();
 
 template<> SOFA_SOFTROBOTS_API
-void PositionModel<defaulttype::Vec3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color);
+void PositionModel<sofa::defaulttype::Vec3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  sofa::type::RGBAColor& color);
 
 template<> SOFA_SOFTROBOTS_API
-void PositionModel<defaulttype::Vec2Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color);
+void PositionModel<sofa::defaulttype::Vec2Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  sofa::type::RGBAColor& color);
 
 template<> SOFA_SOFTROBOTS_API
-void PositionModel<defaulttype::Rigid3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color);
+void PositionModel<sofa::defaulttype::Rigid3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  sofa::type::RGBAColor& color);
 
 #if !defined(SOFTROBOTS_POSITIONMODEL_CPP)
 extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec3Types>;
@@ -137,9 +132,6 @@ extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec2T
 extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace constraintset
+} // namespace
 
-} // namespace component
-
-} // namespace sofa
 

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -92,7 +92,7 @@ protected:
     Data<Real>                                  d_weight;
     Data<VecDeriv>                                d_directions;
     Data<Vec<Deriv::total_size,bool>>             d_useDirections;
-    Data<type::vector<double>>                    d_delta;
+    Data<type::vector<Real>>                    d_delta;
 
     ////////////////////////// Inherited attributes ////////////////////////////
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -95,10 +95,6 @@ protected:
     Data<type::vector<double>>                    d_delta;
 
     ////////////////////////// Inherited attributes ////////////////////////////
-    /// https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
-    /// Bring inherited attributes and function in the current lookup context.
-    /// otherwise any access to the base::attribute would require
-    /// the "this->" approach.
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
     using SoftRobotsConstraint<DataTypes>::m_constraintId ;
     using SoftRobotsConstraint<DataTypes>::d_componentState ;

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -91,7 +91,7 @@ protected:
     Data<type::vector<unsigned int> >             d_indices;
     Data<Real>                                  d_weight;
     Data<VecDeriv>                                d_directions;
-    Data<Vec<Deriv::total_size,bool>>             d_useDirections;
+    Data<sofa::type::fixed_array<Deriv::total_size,bool>>             d_useDirections;
     Data<type::vector<Real>>                    d_delta;
 
     ////////////////////////// Inherited attributes ////////////////////////////

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -128,8 +128,6 @@ void PositionModel<defaulttype::Vec2Types>::drawPoints(const VisualParams* vpara
 template<> SOFA_SOFTROBOTS_API
 void PositionModel<defaulttype::Rigid3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color);
 
-// Declares template as extern to avoid the code generation of the template for
-// each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 #if !defined(SOFTROBOTS_POSITIONMODEL_CPP)
 extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec3Types>;
 extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec2Types>;

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -1,6 +1,6 @@
 /******************************************************************************
-*       SOFA, Simulation Open-Framework Architecture, version 1.0 RC 1        *
-*                (c) 2006-2011 MGH, INRIA, USTL, UJF, CNRS                    *
+*               SOFA, Simulation Open-Framework Architecture                  *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This library is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU Lesser General Public License as published by    *
@@ -16,13 +16,16 @@
 * along with this library; if not, write to the Free Software Foundation,     *
 * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
 *******************************************************************************
-*                               SOFA :: Modules                               *
+*                           Plugin SoftRobots v1.0                            *
 *                                                                             *
-* This component is not open-source                                           *
+* This plugin is also distributed under the GNU LGPL (Lesser General          *
+* Public License) license with the same conditions than SOFA.                 *
 *                                                                             *
-* Authors: Christian Duriez                                                   *
+* Contributors: Defrost team  (INRIA, University of Lille, CNRS,              *
+*               Ecole Centrale de Lille)                                      *
 *                                                                             *
-* Contact information: contact@sofa-framework.org                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+*                                                                             *
 ******************************************************************************/
 #pragma once
 
@@ -91,7 +94,7 @@ protected:
     Data<type::vector<unsigned int> >             d_indices;
     Data<Real>                                  d_weight;
     Data<VecDeriv>                                d_directions;
-    Data<sofa::type::fixed_array<Deriv::total_size,bool>>             d_useDirections;
+    Data<Vec<Deriv::total_size, bool>>             d_useDirections;
     Data<type::vector<Real>>                    d_delta;
 
     ////////////////////////// Inherited attributes ////////////////////////////

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -1,0 +1,148 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, version 1.0 RC 1        *
+*                (c) 2006-2011 MGH, INRIA, USTL, UJF, CNRS                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                               SOFA :: Modules                               *
+*                                                                             *
+* This component is not open-source                                           *
+*                                                                             *
+* Authors: Christian Duriez                                                   *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SoftRobots/component/behavior/SoftRobotsConstraint.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace constraintset
+{
+using sofa::core::behavior::SoftRobotsConstraint ;
+using sofa::core::ConstraintParams ;
+using sofa::linearalgebra::BaseVector ;
+using sofa::type::Vec ;
+using sofa::core::visual::VisualParams ;
+
+/**
+ * This class contains common implementation of position constraints
+*/
+template< class DataTypes >
+class PositionModel : virtual public SoftRobotsConstraint<DataTypes>
+{
+public:
+    SOFA_CLASS(SOFA_TEMPLATE(PositionModel,DataTypes),
+               SOFA_TEMPLATE(SoftRobotsConstraint,DataTypes));
+
+    typedef typename DataTypes::VecCoord            VecCoord;
+    typedef typename DataTypes::VecDeriv            VecDeriv;
+    typedef typename DataTypes::Coord               Coord;
+    typedef typename DataTypes::Deriv               Deriv;
+    typedef typename DataTypes::MatrixDeriv         MatrixDeriv;
+    typedef typename Coord::value_type              Real;
+    typedef typename core::behavior::MechanicalState<DataTypes> MechanicalState;
+
+    typedef typename DataTypes::MatrixDeriv::RowIterator MatrixDerivRowIterator;
+    typedef Data<VecCoord>                          DataVecCoord;
+    typedef Data<VecDeriv>                          DataVecDeriv;
+    typedef Data<MatrixDeriv>                       DataMatrixDeriv;
+
+public:
+    PositionModel(MechanicalState* object = nullptr);
+    ~PositionModel() override;
+
+    /////////////// Inherited from BaseObject  ////////////
+    void init() override;
+    void reinit() override;
+    void draw(const VisualParams* vparams) override;
+    //////////////////////////////////////////////////////
+
+    /////////////// Inherited from Effector ////////////
+    void buildConstraintMatrix(const ConstraintParams* cParams ,
+                               DataMatrixDeriv &cMatrix,
+                               unsigned int &cIndex,
+                               const DataVecCoord &x) override;
+    ///////////////////////////////////////////////////////////////
+
+
+    /////////////// Inherited from BaseSoftRobotsConstraint ////////////////
+    void storeResults(type::vector<double> &delta) override;
+    ///////////////////////////////////////////////////////////////////////////
+
+protected:
+    Data<type::vector<unsigned int> >             d_indices;
+    Data<double>                                  d_weight;
+    Data<VecDeriv>                                d_directions;
+    Data<Vec<Deriv::total_size,bool>>             d_useDirections;
+    Data<type::vector<double>>                    d_delta;
+
+    ////////////////////////// Inherited attributes ////////////////////////////
+    /// https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
+    /// Bring inherited attributes and function in the current lookup context.
+    /// otherwise any access to the base::attribute would require
+    /// the "this->" approach.
+    using SoftRobotsConstraint<DataTypes>::m_nbLines ;
+    using SoftRobotsConstraint<DataTypes>::m_constraintId ;
+    using SoftRobotsConstraint<DataTypes>::d_componentState ;
+    using SoftRobotsConstraint<DataTypes>::m_state ;
+    ////////////////////////////////////////////////////////////////////////////
+
+    void setDefaultDirections();
+    void setDefaultUseDirections();
+    void normalizeDirections();
+    void drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color) ;
+
+private:
+    void internalInit();
+    void checkIndicesRegardingState();
+    void setIndicesDefaultValue();
+    void resizeIndicesRegardingState();
+
+
+};
+
+
+template<> SOFA_SOFTROBOTS_API
+void PositionModel<defaulttype::Rigid3Types>::normalizeDirections();
+
+template<> SOFA_SOFTROBOTS_API
+void PositionModel<defaulttype::Vec3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color);
+
+template<> SOFA_SOFTROBOTS_API
+void PositionModel<defaulttype::Vec2Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color);
+
+template<> SOFA_SOFTROBOTS_API
+void PositionModel<defaulttype::Rigid3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  type::RGBAColor& color);
+
+// Declares template as extern to avoid the code generation of the template for
+// each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
+#if !defined(SOFTROBOTS_POSITIONMODEL_CPP)
+extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec3Types>;
+extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec2Types>;
+extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Rigid3Types>;
+#endif
+
+} // namespace constraintset
+
+} // namespace component
+
+} // namespace sofa
+

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -89,7 +89,7 @@ public:
 
 protected:
     Data<type::vector<unsigned int> >             d_indices;
-    Data<double>                                  d_weight;
+    Data<Real>                                  d_weight;
     Data<VecDeriv>                                d_directions;
     Data<Vec<Deriv::total_size,bool>>             d_useDirections;
     Data<type::vector<double>>                    d_delta;

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -165,9 +165,10 @@ void PositionModel<DataTypes>::checkIndicesRegardingState()
         return;
     }
 
-    for(unsigned int i=0; i<d_indices.getValue().size(); i++)
+    const auto& indices = d_indices.getValue();
+    for(unsigned int i=0; i<indices .size(); i++)
     {
-        if (positions.size() <= d_indices.getValue()[i])
+        if (positions.size() <= indices[i])
         {
             msg_error(this) << "Indices at index " << i << " is to large regarding mechanicalState [position] size" ;
             d_componentState = ComponentState::Invalid;

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -253,8 +253,7 @@ template<class DataTypes>
 void PositionModel<DataTypes>::setDefaultUseDirections()
 {
     Vec<Deriv::total_size,bool> useDirections;
-    for(Size i=0; i<Deriv::total_size; i++)
-        useDirections[i] = true;
+    useDirections.assign(true);
     d_useDirections.setValue(useDirections);
 }
 

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -118,12 +118,8 @@ void PositionModel<DataTypes>::internalInit()
     }
     else
     {
-        int count = 0;
-        for(Size i=0; i<Deriv::total_size; i++)
-            if(d_useDirections.getValue()[i])
-                count++;
-
-        if(count==0)
+        const auto useDirections = sofa::helper::getReadAccessor(d_useDirections);
+        if (std::find(useDirections.begin(), useDirections().end(), true) == useDirections.cend())
         {
             setDefaultUseDirections();
             msg_warning(this) << "No direction given in useDirection. Set default all.";

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -208,11 +208,11 @@ void PositionModel<DataTypes>::buildConstraintMatrix(const ConstraintParams* cPa
 
     m_constraintId = cIndex;
     MatrixDeriv& column = *cMatrix.beginEdit();
-    const auto indices = sofa::helper::getReadAccessor(d_indices);
+    const auto& indices = sofa::helper::getReadAccessor(d_indices);
     sofa::Index sizeIndices = indices.size();
-    const auto useDirections = sofa::helper::getReadAccessor(d_useDirections);
-    const auto directions = sofa::helper::getReadAccessor(d_directions);
-    const auto weight = sofa::helper::getReadAccessor(d_weight);
+    const auto& useDirections = sofa::helper::getReadAccessor(d_useDirections);
+    const auto& directions = sofa::helper::getReadAccessor(d_directions);
+    const auto& weight = sofa::helper::getReadAccessor(d_weight);
 
     unsigned int index = 0;
     for (unsigned i=0; i<sizeIndices; i++)

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -246,8 +246,7 @@ void PositionModel<DataTypes>::storeResults(vector<double> &delta)
 template<class DataTypes>
 void PositionModel<DataTypes>::setDefaultDirections()
 {
-    VecDeriv directions;
-    directions.resize(Deriv::total_size);
+    VecDeriv directions(Deriv::total_size);
     for(Size i=0; i<Deriv::total_size; i++)
         directions[i][i] = 1.;
     d_directions.setValue(directions);

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -284,7 +284,7 @@ void PositionModel<DataTypes>::draw(const VisualParams* vparams)
     {
         points.push_back(positions[indices[i]]);
     }
-    drawPoints(vparams, points, 10.0f, RGBAColor(0.,1.,0.,1.));
+    drawPoints(vparams, points, 10.0f, RGBAColor::green());
 }
 
 } // namespace constraintset

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -34,7 +34,7 @@
 
 #include <SoftRobots/component/constraint/model/PositionModel.h>
 
-namespace sofa::component::constraintset
+namespace softrobots::constraintset
 {
 
 using sofa::core::objectmodel::ComponentState;
@@ -154,7 +154,7 @@ void PositionModel<DataTypes>::internalInit()
 template<class DataTypes>
 void PositionModel<DataTypes>::checkIndicesRegardingState()
 {
-    ReadAccessor<Data<VecCoord> > positions = m_state->readPositions();
+    ReadAccessor<sofa::Data<VecCoord> > positions = m_state->readPositions();
 
     if(d_indices.getValue().size() > positions.size())
     {
@@ -181,14 +181,14 @@ void PositionModel<DataTypes>::checkIndicesRegardingState()
 template<class DataTypes>
 void PositionModel<DataTypes>::setIndicesDefaultValue()
 {
-    WriteAccessor<Data<vector<unsigned int> > > defaultIndices = d_indices;
+    WriteAccessor<sofa::Data<vector<unsigned int> > > defaultIndices = d_indices;
     defaultIndices.resize(1);
 }
 
 template<class DataTypes>
 void PositionModel<DataTypes>::resizeIndicesRegardingState()
 {
-    WriteAccessor<Data<vector<unsigned int>>> indices = d_indices;
+    WriteAccessor<sofa::Data<vector<unsigned int>>> indices = d_indices;
     indices.resize(m_state->getSize());
 }
 
@@ -217,7 +217,7 @@ void PositionModel<DataTypes>::buildConstraintMatrix(const ConstraintParams* cPa
     unsigned int index = 0;
     for (unsigned i=0; i<sizeIndices; i++)
     {
-        for(Size j=0; j<Deriv::total_size; j++)
+        for(sofa::Size j=0; j<Deriv::total_size; j++)
         {
             if(useDirections[j])
             {
@@ -249,7 +249,7 @@ template<class DataTypes>
 void PositionModel<DataTypes>::setDefaultDirections()
 {
     VecDeriv directions(Deriv::total_size);
-    for(Size i=0; i<Deriv::total_size; i++)
+    for(sofa::Size i=0; i<Deriv::total_size; i++)
         directions[i][i] = 1.;
     d_directions.setValue(directions);
 }
@@ -267,7 +267,7 @@ void PositionModel<DataTypes>::setDefaultUseDirections()
 template<class DataTypes>
 void PositionModel<DataTypes>::normalizeDirections()
 {
-    WriteAccessor<Data<VecDeriv>> directions = d_directions;
+    WriteAccessor<sofa::Data<VecDeriv>> directions = d_directions;
     directions.resize(Deriv::total_size);
     for(unsigned int i=0; i<Deriv::total_size; i++)
         directions[i].normalize();
@@ -283,8 +283,8 @@ void PositionModel<DataTypes>::draw(const VisualParams* vparams)
     if (!vparams->displayFlags().getShowInteractionForceFields())
         return;
 
-    ReadAccessor<Data<VecCoord> > positions = m_state->readPositions();
-    ReadAccessor<Data<type::vector<sofa::Index>> > indices = d_indices;
+    ReadAccessor<sofa::Data<VecCoord> > positions = m_state->readPositions();
+    ReadAccessor<sofa::Data<sofa::type::vector<sofa::Index>> > indices = d_indices;
     vector<Coord> points;
     points.reserve(indices.size());
     for (unsigned int i=0; i<indices.size(); i++)
@@ -294,5 +294,5 @@ void PositionModel<DataTypes>::draw(const VisualParams* vparams)
     drawPoints(vparams, points, 10.0f, RGBAColor::green());
 }
 
-}
+} // namespace
 

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -31,13 +31,7 @@
 
 #include <SoftRobots/component/constraint/model/PositionModel.h>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace constraintset
+namespace sofa::component::constraintset
 {
 
 using sofa::core::objectmodel::ComponentState;

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -170,7 +170,7 @@ void PositionModel<DataTypes>::checkIndicesRegardingState()
     {
         if (positions.size() <= indices[i])
         {
-            msg_error(this) << "Indices at index " << i << " is to large regarding mechanicalState [position] size" ;
+            msg_error(this) << "Index at index " << i << " is too large regarding mechanicalState [position] size" ;
             d_componentState = ComponentState::Invalid;
             return;
         }

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -34,7 +34,7 @@
 
 #include <SoftRobots/component/constraint/model/PositionModel.h>
 
-namespace softrobots::constraintset
+namespace softrobots::constraint
 {
 
 using sofa::core::objectmodel::ComponentState;

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -1,0 +1,306 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, version 1.0 RC 1        *
+*                (c) 2006-2011 MGH, INRIA, USTL, UJF, CNRS                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                               SOFA :: Modules                               *
+*                                                                             *
+* This component is not open-source                                           *
+*                                                                             *
+* Authors: Christian Duriez                                                   *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/logging/Messaging.h>
+
+#include <SoftRobots/component/constraint/model/PositionModel.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace constraintset
+{
+
+using sofa::core::objectmodel::ComponentState;
+using sofa::core::VecCoordId;
+using sofa::core::ConstVecCoordId ;
+using sofa::helper::WriteAccessor ;
+using sofa::helper::ReadAccessor ;
+using sofa::type::vector ;
+using sofa::type::Vec;
+using sofa::type::Vec3;
+using sofa::type::RGBAColor;
+
+template<class DataTypes>
+PositionModel<DataTypes>::PositionModel(MechanicalState* object)
+    : Inherit1(object)
+    , d_indices(initData(&d_indices, "indices",
+                                 "If indices size is lower than target size, \n"
+                                 "some target will not be considered"))
+
+    , d_weight(initData(&d_weight, 1., "weight",
+                          "The parameter sets a weight to the minimization."))
+
+    , d_directions(initData(&d_directions,"directions",
+                          "The parameter directions allows to specify the directions in \n"
+                          "which you want to solve the position."))
+
+    , d_useDirections(initData(&d_useDirections,"useDirections",
+                              "The parameter useDirections allows to select the directions in \n"
+                              "which you want to solve the position. If unspecified, the default \n"
+                              "values are all true."))
+
+    , d_delta(initData(&d_delta, "delta","Distance to target"))
+{
+    d_delta.setReadOnly(true);
+}
+
+
+
+template<class DataTypes>
+PositionModel<DataTypes>::~PositionModel()
+{
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::init()
+{
+    d_componentState = ComponentState::Valid;
+    Inherit1::init();
+
+    if(m_state==nullptr)
+    {
+        msg_error() << "There is no mechanical state associated with this node. "
+                        "the object is deactivated. "
+                        "To remove this error message fix your scene possibly by "
+                        "adding a MechanicalObject." ;
+        d_componentState = ComponentState::Invalid;
+        return;
+    }
+
+    internalInit();
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::reinit()
+{
+    internalInit();
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::internalInit()
+{
+    if(!d_directions.isSet())
+        setDefaultDirections();
+    else
+        normalizeDirections();
+
+
+    if(!d_useDirections.isSet())
+    {
+        setDefaultUseDirections();
+    }
+    else
+    {
+        int count = 0;
+        for(Size i=0; i<Deriv::total_size; i++)
+            if(d_useDirections.getValue()[i])
+                count++;
+
+        if(count==0)
+        {
+            setDefaultUseDirections();
+            msg_warning(this) << "No direction given in useDirection. Set default all.";
+        }
+    }
+
+    if(!d_indices.isSet())
+    {
+        msg_warning(this) <<"Indices not defined. Default value assigned 0.";
+        setIndicesDefaultValue();
+    }
+
+    if(d_indices.getValue().size() > m_state->getSize())
+    {
+        msg_warning(this) <<"Indices size can not be larger than the number of point in the context. Launch resize process.";
+        resizeIndicesRegardingState();
+    }
+
+    if(d_indices.getValue().size() == 0)
+    {
+        msg_error(this) <<"Indices size is zero. The component will not work.";
+        d_componentState = ComponentState::Invalid;
+        return;
+    }
+
+    checkIndicesRegardingState();
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::checkIndicesRegardingState()
+{
+    ReadAccessor<Data<VecCoord> > positions = m_state->readPositions();
+
+    if(d_indices.getValue().size() > positions.size())
+    {
+        msg_error(this) << "Indices size is larger than mechanicalState size" ;
+        d_componentState = ComponentState::Invalid;
+        return;
+    }
+
+    for(unsigned int i=0; i<d_indices.getValue().size(); i++)
+    {
+        if (positions.size() <= d_indices.getValue()[i])
+        {
+            msg_error(this) << "Indices at index " << i << " is to large regarding mechanicalState [position] size" ;
+            d_componentState = ComponentState::Invalid;
+            return;
+        }
+    }
+}
+
+
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::setIndicesDefaultValue()
+{
+    WriteAccessor<Data<vector<unsigned int> > > defaultIndices = d_indices;
+    defaultIndices.resize(1);
+}
+
+template<class DataTypes>
+void PositionModel<DataTypes>::resizeIndicesRegardingState()
+{
+    WriteAccessor<Data<vector<unsigned int>>> indices = d_indices;
+    indices.resize(m_state->getSize());
+}
+
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::buildConstraintMatrix(const ConstraintParams* cParams,
+                                                        DataMatrixDeriv &cMatrix,
+                                                        unsigned int &cIndex,
+                                                        const DataVecCoord &x)
+{
+    if(d_componentState.getValue() != ComponentState::Valid)
+        return;
+
+    SOFA_UNUSED(cParams);
+    SOFA_UNUSED(x);
+
+    m_constraintId = cIndex;
+    MatrixDeriv& column = *cMatrix.beginEdit();
+    sofa::Index sizeIndices = d_indices.getValue().size();
+
+    unsigned int index = 0;
+    for (unsigned i=0; i<sizeIndices; i++)
+    {
+        for(Size j=0; j<Deriv::total_size; j++)
+        {
+            if(d_useDirections.getValue()[j])
+            {
+                MatrixDerivRowIterator rowIterator = column.writeLine(m_constraintId+index);
+                rowIterator.setCol(d_indices.getValue()[i], d_directions.getValue()[j]*d_weight.getValue());
+                index++;
+            }
+        }
+    }
+
+    cIndex += index;
+    cMatrix.endEdit();
+
+    m_nbLines = cIndex - m_constraintId;
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::storeResults(vector<double> &delta)
+{
+    if(d_componentState.getValue() != ComponentState::Valid)
+        return;
+
+    d_delta.setValue(delta);
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::setDefaultDirections()
+{
+    VecDeriv directions;
+    directions.resize(Deriv::total_size);
+    for(Size i=0; i<Deriv::total_size; i++)
+        directions[i][i] = 1.;
+    d_directions.setValue(directions);
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::setDefaultUseDirections()
+{
+    Vec<Deriv::total_size,bool> useDirections;
+    for(Size i=0; i<Deriv::total_size; i++)
+        useDirections[i] = true;
+    d_useDirections.setValue(useDirections);
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::normalizeDirections()
+{
+    WriteAccessor<Data<VecDeriv>> directions = d_directions;
+    directions.resize(Deriv::total_size);
+    for(unsigned int i=0; i<Deriv::total_size; i++)
+        directions[i].normalize();
+}
+
+
+template<class DataTypes>
+void PositionModel<DataTypes>::draw(const VisualParams* vparams)
+{
+    if(d_componentState.getValue() != ComponentState::Valid)
+        return;
+
+    if (!vparams->displayFlags().getShowInteractionForceFields())
+        return;
+
+    vector<Coord> points;
+    ReadAccessor<Data<VecCoord> > positions = m_state->readPositions();
+    ReadAccessor<Data<type::vector<sofa::Index>> > indices = d_indices;
+    for (unsigned int i=0; i<indices.size(); i++)
+    {
+        points.push_back(positions[indices[i]]);
+    }
+    drawPoints(vparams, points, 10.0f, RGBAColor(0.,1.,0.,1.));
+}
+
+} // namespace constraintset
+
+} // namespace component
+
+} // namespace sofa
+


### PR DESCRIPTION
This PR adds two classes:
- PositionConstraint: this component allows to impose a displacement to a set of points, using a constraint approach with Lagrange's multipliers. See example `docs/sofapython3/examples/component/constraint/PositionConstraint/PositionConstraint.py`. 
- PositionModel: shared implementation of PositionConstraint and PositionEffector (for inverse resolution).