### PR TITLE
Fix source code archives assets from release branch and not master.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAGNAME }}
           fail_on_unmatched_files: false
+          target_commitish: ${{ env.RELEASE_NAME }}
           body: |
             Last updated on ${{ env.RELEASE_DATE }}
           files: |


### PR DESCRIPTION
Source code archives (zip and tar) are generated from `master` branch instead of `v23.06`. Other assets (releases for Windows, Linux and MacOS) are generated from correct branch.