### PR TITLE
Fix softprops/action-gh-release source from master to release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAGNAME }}
           fail_on_unmatched_files: true
+          target_commitish: ${{ env.RELEASE_NAME }}
           body: |
             Last updated on ${{ env.RELEASE_DATE }}
           files: |


### PR DESCRIPTION
The `softprops/action-gh-release` Github action used in the CI to deploy assets was incorrectly configured to the `master` branch (default behavior), instead of the current release set by the `sofa_branch` field in the `build-and-test` matrix.
This lead to the following undesired behavior:
- source code archives (zip and tar) were generated from master branch instead of release branch. Other assets (releases for Windows, Linux and MacOS) were generated from correct branch.
- release tag pushed by this action (tag in the form `release-<version>`) was incorrectly set to `master` branch, which is invalid when current release is not `master` (such as `v<version>`)