### PR TITLE
Remove python2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,6 @@ if(Sofa.GL_FOUND)
     target_link_libraries(${PROJECT_NAME} Sofa.GL)
 endif()
 
-sofa_install_pythonscripts(PLUGIN_NAME ${PROJECT_NAME} PYTHONSCRIPTS_SOURCE_DIR "python")
 find_file(SofaPython3Tools NAMES "SofaPython3/lib/cmake/SofaPython3/SofaPython3Tools.cmake")
 if(SofaPython3Tools)
     message("-- Found SofaPython3Tools. Python3 packages will be installed.")


### PR DESCRIPTION
This PR removes plugin python2 support. This will avoid polluting etc/sofa/python.d/ path with some invalid python paths that would be then considered in the setup python environment phase of SofaPython3 plugin.