### PR TITLE
Revert #247

### DIFF
--- a/examples/tutorials/CableGripper/details/step0.py
+++ b/examples/tutorials/CableGripper/details/step0.py
@@ -24,6 +24,6 @@ def createScene(rootNode):
                 volume=20,
                 inertiaMatrix=[1000.0, 0.0, 0.0, 0.0, 1000.0, 0.0, 0.0, 0.0, 1000.0],
                 translation=[0.0, -130.0, 10.0])
-    cube.addObject('UncoupledConstraintCorrection', defaultCompliance=1e-5)
+    cube.addObject('UncoupledConstraintCorrection')
 
     return rootNode

--- a/examples/tutorials/CableGripper/details/step6.py
+++ b/examples/tutorials/CableGripper/details/step6.py
@@ -24,6 +24,7 @@ def createScene(rootNode):
                 volume=20,
                 inertiaMatrix=[1000.0, 0.0, 0.0, 0.0, 1000.0, 0.0, 0.0, 0.0, 1000.0],
                 translation=[0.0, -130.0, 10.0])
-    cube.addObject('UncoupledConstraintCorrection', defaultCompliance=1e-5)
+
+    cube.addObject('UncoupledConstraintCorrection')
 
     return rootNode

--- a/examples/tutorials/FirstSteps/details/step1.py
+++ b/examples/tutorials/FirstSteps/details/step1.py
@@ -32,6 +32,6 @@ def createScene(rootNode):
     cube = Cube(rootNode, translation=[0.0, 0.0, 0.0],
                 uniformScale=20.0)
 
-    cube.addObject('UncoupledConstraintCorrection', defaultCompliance=1e-5)
+    cube.addObject('UncoupledConstraintCorrection')
 
     return rootNode

--- a/examples/tutorials/FirstSteps/details/step3.py
+++ b/examples/tutorials/FirstSteps/details/step3.py
@@ -40,7 +40,7 @@ def createScene(rootNode):
     cube.addObject('UniformMass', name="vertexMass", vertexMass=[totalMass, volume, inertiaMatrix[:]])
 
     # Material behaviour when submitted to constraints
-    cube.addObject('UncoupledConstraintCorrection', defaultCompliance=1e-5)
+    cube.addObject('UncoupledConstraintCorrection')
 
     # Time integration and solver
 

--- a/examples/tutorials/FirstSteps/details/step4.py
+++ b/examples/tutorials/FirstSteps/details/step4.py
@@ -45,6 +45,7 @@ def createScene(rootNode):
                     translation=[-210 + c * 70, 0.0, 0.0],
                     color=[c / 10.0, c * 0.7 / 10.0, 0.9, 1.0],
                     uniformScale=20.0)
-        cube.addObject('UncoupledConstraintCorrection', defaultCompliance=1e-5)
+
+        cube.addObject('UncoupledConstraintCorrection')
 
     return rootNode

--- a/examples/tutorials/PneunetGripper/details/step7-grabTheCube.py
+++ b/examples/tutorials/PneunetGripper/details/step7-grabTheCube.py
@@ -78,7 +78,7 @@ def createScene(rootNode):
     cube.addObject('EulerImplicitSolver')
     cube.addObject('CGLinearSolver', threshold=1e-5, tolerance=1e-5, iterations=50)
     cube.addObject('MechanicalObject', template='Rigid3', position=[-100, 70, 0, 0, 0, 0, 1])
-    cube.addObject('UniformMass', totalMass=0.01)
+    cube.addObject('UniformMass', totalMass=0.001)
     cube.addObject('UncoupledConstraintCorrection')
 
     # collision

--- a/examples/tutorials/PneunetGripper/details/step7-withSTLIB.py
+++ b/examples/tutorials/PneunetGripper/details/step7-withSTLIB.py
@@ -52,7 +52,7 @@ def createScene(rootNode):
     Floor(rootNode, **floorParam)
 
     cube = Cube(rootNode, **cubeParam)
-    cube.addObject('UncoupledConstraintCorrection', defaultCompliance=1e-5)
+    cube.addObject('UncoupledConstraintCorrection')
 
     for i in range(len(fingersParameters)):
         finger = ElasticMaterialObject(attachedTo=rootNode,

--- a/examples/tutorials/Tripod/details/maze.py
+++ b/examples/tutorials/Tripod/details/maze.py
@@ -79,7 +79,7 @@ def createScene(rootNode):
     effector.addObject('MechanicalObject', template='Rigid3', name='goalMO', position=[0, 40, 0, 0, 0, 0, 1],
                        showObject=True, showObjectScale=10)
     effector.addObject('RestShapeSpringsForceField', points=0, angularStiffness=1e5, stiffness=1e5)
-    effector.addObject('UncoupledConstraintCorrection', compliance=[1e-10] * 7)
+    effector.addObject('UncoupledConstraintCorrection', compliance='1e-10  1e-10  0 0 1e-10  0 1e-10 ')
 
     # Open maze planning from JSON file
     data = json.load(open('mazeplanning.json'))

--- a/examples/tutorials/Tripod/myproject/maze.py
+++ b/examples/tutorials/Tripod/myproject/maze.py
@@ -79,7 +79,7 @@ def createScene(rootNode):
     effector.addObject('MechanicalObject', template='Rigid3', name='goalMO', position=[0, 40, 0, 0, 0, 0, 1],
                        showObject=True, showObjectScale=10)
     effector.addObject('RestShapeSpringsForceField', points=0, angularStiffness=1e5, stiffness=1e5)
-    effector.addObject('UncoupledConstraintCorrection', compliance=[1e-10] * 7)
+    effector.addObject('UncoupledConstraintCorrection', compliance='1e-10  1e-10  0 0 1e-10  0 1e-10 ')
 
     # Open maze planning from JSON file
     data = json.load(open('mazeplanning.json'))

--- a/examples/tutorials/Tripod/myproject/parts/maze.py
+++ b/examples/tutorials/Tripod/myproject/parts/maze.py
@@ -57,7 +57,7 @@ def createScene(rootNode):
     effector.addObject('MechanicalObject', template='Rigid3', name='goalMO', position=[0, 40, 0, 0, 0, 0, 1],
                        showObject=True, showObjectScale=10)
     effector.addObject('RestShapeSpringsForceField', points=0, angularStiffness=1e5, stiffness=1e5)
-    effector.addObject('UncoupledConstraintCorrection', compliance=[1e-10] * 7)
+    effector.addObject('UncoupledConstraintCorrection', compliance='1e-10  1e-10  0 0 1e-10  0 1e-10 ')
 
     # Open maze planning from JSON file
     data = json.load(open('../mazeplanning.json'))


### PR DESCRIPTION
Further to deeper investigation in https://github.com/sofa-framework/sofa/pull/4205, the previous #247 should be reverted.

Other files were already fixed by the team :+1: 

As an explanation/reminder, in a rigid case, the `compliance` data of the UncoupledCC has 7 inputs:
- 1 corresponding to the compliance for the translational dofs
- 6 corresponding to the rotation compliance matrix where zero values are possible OUTSIDE the diagonal