### PR TITLE
[constraint] PositionModel: add features 

### DIFF
--- a/src/SoftRobots/component/constraint/PositionConstraint.inl
+++ b/src/SoftRobots/component/constraint/PositionConstraint.inl
@@ -149,7 +149,7 @@ void PositionConstraint<DataTypes>::getConstraintViolation(const ConstraintParam
         for(sofa::Size j=0; j<DataTypes::Deriv::total_size; j++)
             if(useDirections[j])
             {
-                Real dfree = Jdx->element(index) + d*directions[j]*weight;
+                Real dfree = Jdx->element(index) + d*directions[j]*weight[j];
                 resV->set(m_constraintId+index, dfree);
                 index++;
             }

--- a/src/SoftRobots/component/constraint/model/PositionModel.cpp
+++ b/src/SoftRobots/component/constraint/model/PositionModel.cpp
@@ -53,6 +53,11 @@ void PositionModel<Rigid3Types>::normalizeDirections()
     d_directions.setValue(directions);
 }
 
+
+template<>
+void PositionModel<Vec1Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  RGBAColor& color) {
+}
+
 template<>
 void PositionModel<Vec3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  RGBAColor& color) {
     vparams->drawTool()->drawPoints(points, size, color);
@@ -75,8 +80,9 @@ void PositionModel<Rigid3Types>::drawPoints(const VisualParams* vparams, const s
 }
 
 using namespace sofa::defaulttype;
+template class SOFA_SOFTROBOTS_API PositionModel<Vec1Types>;
+template class SOFA_SOFTROBOTS_API PositionModel<Vec2Types>;
 template class SOFA_SOFTROBOTS_API PositionModel<Vec3Types>;
 template class SOFA_SOFTROBOTS_API PositionModel<Rigid3Types>;
-template class SOFA_SOFTROBOTS_API PositionModel<Vec2Types>;
 
 } // namespace

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -85,7 +85,7 @@ public:
 
 protected:
     sofa::Data<sofa::type::vector<unsigned int> >     d_indices;
-    sofa::Data<Real>                                  d_weight;
+    sofa::Data<sofa::type::vector<Real>>              d_weight;
     sofa::Data<VecDeriv>                              d_directions;
     sofa::Data<Vec<Deriv::total_size, bool>>          d_useDirections;
     sofa::Data<sofa::type::vector<Real>>              d_delta;
@@ -125,8 +125,9 @@ template<> SOFA_SOFTROBOTS_API
 void PositionModel<sofa::defaulttype::Rigid3Types>::drawPoints(const VisualParams* vparams, const std::vector<Coord> &points, float size,  const  sofa::type::RGBAColor& color);
 
 #if !defined(SOFTROBOTS_POSITIONMODEL_CPP)
-extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec3Types>;
+extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec1Types>;
 extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec2Types>;
+extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Vec3Types>;
 extern template class SOFA_SOFTROBOTS_API PositionModel<sofa::defaulttype::Rigid3Types>;
 #endif
 

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -52,7 +52,7 @@ PositionModel<DataTypes>::PositionModel(MechanicalState* object)
                                  "If indices size is lower than target size, \n"
                                  "some target will not be considered"))
 
-    , d_weight(initData(&d_weight, 1., "weight",
+    , d_weight(initData(&d_weight, sofa::type::vector<Real>(Deriv::total_size, 1.), "weight",
                           "The parameter sets a weight to the minimization."))
 
     , d_directions(initData(&d_directions,"directions",
@@ -67,8 +67,21 @@ PositionModel<DataTypes>::PositionModel(MechanicalState* object)
     , d_delta(initData(&d_delta, "delta","Distance to target"))
 {
     d_delta.setReadOnly(true);
-}
 
+    this->addUpdateCallback("updateWeight", {&d_weight}, [this](const sofa::core::DataTracker& t)
+                            {
+                                SOFA_UNUSED(t);
+                                auto weight = sofa::helper::getWriteAccessor(d_weight);
+                                if (weight.size() != Deriv::total_size)
+                                {
+                                    msg_info() << "Wrong size for the data field weight, " << weight.size() <<
+                                        " instead of " << Deriv::total_size << ". Resizing, with weight[0] as the default value.";
+                                    Real w = weight.empty()? 1.: weight[0];
+                                    d_weight.setValue(sofa::type::vector<Real>(Deriv::total_size, w));
+                                }
+                                return sofa::core::objectmodel::ComponentState::Valid;
+                            }, {});
+}
 
 
 template<class DataTypes>
@@ -220,7 +233,7 @@ void PositionModel<DataTypes>::buildConstraintMatrix(const ConstraintParams* cPa
             if(useDirections[j])
             {
                 MatrixDerivRowIterator rowIterator = column.writeLine(m_constraintId+index);
-                rowIterator.setCol(indices[i], directions[j]*weight);
+                rowIterator.setCol(indices[i], directions[j]*weight[j]);
                 index++;
             }
         }


### PR DESCRIPTION
In this PR: 
- adds Vec1 template to PositionModel
- the `weight` can now be an array. Does not break, nor change the previous usage.  