### PR TITLE
Try to fix scene timeout on ubuntu

### DIFF
--- a/examples/.scene-tests
+++ b/examples/.scene-tests
@@ -34,3 +34,6 @@ ignore "tutorials/Tripod/myproject/parts/tripodcontroller.py"
 # Ignore because CI finds a createScene function, so it is considered as a functional scene. But it is in the comments,
 # so it should be ignored
 ignore "component/controller/AnimationEditor/__init__.py"
+
+#Fix random timeout on ubuntu
+timeout "thematicalDocs/T4-DirectActuation/Actuators/Pneumatic.SurfaceConstraintPressure.py" "45"


### PR DESCRIPTION
Jenkins CI was experiencing timeout on this scene near the end of the execution. 
--> see [log](https://ci.inria.fr/sofa-ci-dev/job/sofa-framework/job/PR-4679/CI_CONFIG=ubuntu_gcc,CI_PLUGINS=options,CI_TYPE=release/22/testReport/SceneTests/applications_plugins_SoftRobots_examples_thematicalDocs_T4-DirectActuation_Actuators_Pneumatic/SurfaceConstraintPressure_py/)