### PR TITLE
Update macos runner to arm64 arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
         sofa_branch: [master]
 
     steps:


### PR DESCRIPTION
SOFA binaries for macOS are now generated using macos-14 runner which uses an arm64 architecture. We have to update our macOS runner consequently here to be able to compile with the arm64 SOFA binaries under macOS.