### PR TITLE
[constraint] Refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,9 @@ if(SofaPython3Tools OR SofaPython3_FOUND)
         SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python3/softrobots
         TARGET_DIRECTORY softrobots
     )
+    add_subdirectory(${SOFTROBOTS_SOURCE_DIR}/bindings)
 endif()
+
 
 ## Install rules for the library and headers; CMake package configurations files
 sofa_create_package_with_targets(

--- a/src/SoftRobots/bindings/Binding_SoftRobotsBaseConstraint.cpp
+++ b/src/SoftRobots/bindings/Binding_SoftRobotsBaseConstraint.cpp
@@ -1,0 +1,54 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                           Plugin SoftRobots                                 *
+*                                                                             *
+* This plugin is also distributed under the GNU LGPL (Lesser General          *
+* Public License) license with the same conditions than SOFA.                 *
+*                                                                             *
+* Contributors: Defrost team  (INRIA, University of Lille, CNRS,              *
+*               Ecole Centrale de Lille)                                      *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+******************************************************************************/
+#include <SoftRobots/bindings/Binding_SoftRobotsBaseConstraint.h>
+#include <pybind11/pybind11.h>
+
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/PythonFactory.h>
+
+#include <SoftRobots/component/behavior/SoftRobotsBaseConstraint.h>
+
+namespace py { using namespace pybind11; }
+
+namespace softrobots::python3 {
+
+void moduleAddSoftRobotsBaseConstraint(py::module &m)
+{
+    const auto typeName = softrobots::behavior::SoftRobotsBaseConstraint::GetClass()->className;
+    py::class_<softrobots::behavior::SoftRobotsBaseConstraint,
+               sofa::core::objectmodel::BaseComponent,
+               sofapython3::py_shared_ptr<softrobots::behavior::SoftRobotsBaseConstraint> > c(m, typeName.c_str());
+
+    /// register the binding in the downcasting subsystem
+    sofapython3::PythonFactory::registerType<softrobots::behavior::SoftRobotsBaseConstraint>([](sofa::core::objectmodel::Base* object)
+    {
+        return py::cast(dynamic_cast<softrobots::behavior::SoftRobotsBaseConstraint*>(object));
+    });
+}
+
+}

--- a/src/SoftRobots/bindings/Binding_SoftRobotsBaseConstraint.h
+++ b/src/SoftRobots/bindings/Binding_SoftRobotsBaseConstraint.h
@@ -1,0 +1,39 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                           Plugin SoftRobots                                 *
+*                                                                             *
+* This plugin is also distributed under the GNU LGPL (Lesser General          *
+* Public License) license with the same conditions than SOFA.                 *
+*                                                                             *
+* Contributors: Defrost team  (INRIA, University of Lille, CNRS,              *
+*               Ecole Centrale de Lille)                                      *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace softrobots::python3
+{
+
+void moduleAddSoftRobotsBaseConstraint(pybind11::module &m);
+
+} /// namespace
+

--- a/src/SoftRobots/bindings/CMakeLists.txt
+++ b/src/SoftRobots/bindings/CMakeLists.txt
@@ -1,0 +1,30 @@
+project(SoftRobotsBindings)
+
+set(HEADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SoftRobotsBaseConstraint.h
+)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SoftRobotsBaseConstraint.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Module_SoftRobots.cpp
+)
+
+if (NOT TARGET SofaPython3::Plugin)
+    find_package(SofaPython3 REQUIRED COMPONENTS Plugin Bindings.Sofa)
+endif()
+
+SP3_add_python_module(
+    TARGET       ${PROJECT_NAME}
+    PACKAGE      SoftRobots
+    MODULE       SoftRobots
+    DESTINATION  Sofa
+    SOURCES      ${SOURCE_FILES}
+    HEADERS      ${HEADER_FILES}
+    DEPENDS      SofaPython3::Plugin SofaPython3::Bindings.Sofa SoftRobots
+)
+
+target_sources(SoftRobotsBindings
+  PRIVATE
+    Binding_SoftRobotsBaseConstraint.cpp
+)
+message("-- SofaPython3 bindings for SoftRobots will be created.")

--- a/src/SoftRobots/bindings/Module_SoftRobots.cpp
+++ b/src/SoftRobots/bindings/Module_SoftRobots.cpp
@@ -1,0 +1,43 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                           Plugin SoftRobots                                 *
+*                                                                             *
+* This plugin is also distributed under the GNU LGPL (Lesser General          *
+* Public License) license with the same conditions than SOFA.                 *
+*                                                                             *
+* Contributors: Defrost team  (INRIA, University of Lille, CNRS,              *
+*               Ecole Centrale de Lille)                                      *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+#include <SoftRobots/bindings/Binding_SoftRobotsBaseConstraint.h>
+
+
+namespace py { using namespace pybind11; }
+
+namespace softrobots::python3
+{
+
+PYBIND11_MODULE(SoftRobots, m)
+{
+    moduleAddSoftRobotsBaseConstraint(m);
+}
+
+} // namespace 

--- a/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.cpp
+++ b/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.cpp
@@ -35,7 +35,7 @@ using sofa::type::vector;
 SoftRobotsBaseConstraint::SoftRobotsBaseConstraint()
     :
       d_lambda(initData(&d_lambda, vector<double>(1, 0.0), "force", "Force. Warning: to get the actual force you should divide this value by dt."))
-    , d_delta(initData(&d_delta, vector<double>(1, 0.0), "displacement", "Displacement."))
+    , d_delta(initData(&d_delta, vector<double>(1, 0.0), "displacement", "Displacement compared to the initial value."))
     , m_nbLines(1)
     , m_hasDeltaMax(false)
     , m_hasDeltaMin(false)

--- a/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.cpp
+++ b/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.cpp
@@ -185,28 +185,38 @@ void SoftRobotsBaseConstraint::storeResults(vector<double> &delta)
 }
 
 
-void SoftRobotsBaseConstraint::setLambdaDescription(const std::string& name, const std::string& help)
+void SoftRobotsBaseConstraint::setLambdaNameAndHelp(const std::string& name, const std::string& help)
 {
-    if (!name.empty())
-    {
-        addAlias(&d_lambda, name.c_str());
-        d_lambda.setName(name);
-    }
-
-    if (!help.empty())
-        d_lambda.setHelp(help);
+    setLambdaName(name);
+    setLambdaHelp(help);
 }
 
-void SoftRobotsBaseConstraint::setDeltaDescription(const std::string& name, const std::string& help)
+void SoftRobotsBaseConstraint::setLambdaName(const std::string& name)
 {
-    if (!name.empty())
-    {
-        addAlias(&d_delta, name.c_str());
-        d_delta.setName(name);
-    }
+    addAlias(&d_lambda, name.c_str());
+    d_lambda.setName(name);
+}
 
-    if (!help.empty())
-        d_delta.setHelp(help);
+void SoftRobotsBaseConstraint::setLambdaHelp(const std::string& help)
+{
+    d_lambda.setHelp(help);
+}
+
+void SoftRobotsBaseConstraint::setDeltaNameAndHelp(const std::string& name, const std::string& help)
+{
+    setDeltaName(name);
+    setDeltaHelp(help);
+}
+
+void SoftRobotsBaseConstraint::setDeltaName(const std::string& name)
+{
+    addAlias(&d_delta, name.c_str());
+    d_delta.setName(name);
+}
+
+void SoftRobotsBaseConstraint::setDeltaHelp(const std::string& help)
+{
+    d_delta.setHelp(help);
 }
 
 void SoftRobotsBaseConstraint::resizeConstraints(const sofa::Size& size)

--- a/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.cpp
+++ b/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.cpp
@@ -184,6 +184,31 @@ void SoftRobotsBaseConstraint::storeResults(vector<double> &delta)
     SOFA_UNUSED(delta);
 }
 
+
+void SoftRobotsBaseConstraint::setLambdaDescription(const std::string& name, const std::string& help)
+{
+    if (!name.empty())
+    {
+        addAlias(&d_lambda, name.c_str());
+        d_lambda.setName(name);
+    }
+
+    if (!help.empty())
+        d_lambda.setHelp(help);
+}
+
+void SoftRobotsBaseConstraint::setDeltaDescription(const std::string& name, const std::string& help)
+{
+    if (!name.empty())
+    {
+        addAlias(&d_delta, name.c_str());
+        d_delta.setName(name);
+    }
+
+    if (!help.empty())
+        d_delta.setHelp(help);
+}
+
 void SoftRobotsBaseConstraint::resizeConstraints(const sofa::Size& size)
 {
     m_nbLines = size;

--- a/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.cpp
+++ b/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.cpp
@@ -33,7 +33,11 @@ namespace softrobots::behavior
 using sofa::type::vector;
 
 SoftRobotsBaseConstraint::SoftRobotsBaseConstraint()
-    : m_hasDeltaMax(false)
+    :
+      d_lambda(initData(&d_lambda, vector<double>(1, 0.0), "force", "Force. Warning: to get the actual force you should divide this value by dt."))
+    , d_delta(initData(&d_delta, vector<double>(1, 0.0), "displacement", "Displacement."))
+    , m_nbLines(1)
+    , m_hasDeltaMax(false)
     , m_hasDeltaMin(false)
     , m_hasDeltaEqual(false)
     , m_hasLambdaMax(false)
@@ -43,6 +47,8 @@ SoftRobotsBaseConstraint::SoftRobotsBaseConstraint()
     , m_hasEpsilon(false)
 {
     d_constraintIndex.setReadOnly(true);
+
+    resizeConstraints(m_nbLines);
 }
 
 bool SoftRobotsBaseConstraint::hasDeltaMax() const
@@ -94,9 +100,19 @@ SReal SoftRobotsBaseConstraint::getDeltaMax(const size_t i) const
     return m_deltaMax[i];
 }
 
+vector<double> SoftRobotsBaseConstraint::getDeltaMax() const
+{
+    return m_deltaMax;
+}
+
 SReal SoftRobotsBaseConstraint::getDeltaMin(const size_t i) const
 {
     return m_deltaMin[i];
+}
+
+vector<double> SoftRobotsBaseConstraint::getDeltaMin() const
+{
+    return m_deltaMin;
 }
 
 SReal SoftRobotsBaseConstraint::getDeltaEqual(const size_t i) const
@@ -111,9 +127,19 @@ SReal SoftRobotsBaseConstraint::getLambdaMax(const size_t i) const
     return m_lambdaMax[i];
 }
 
+vector<double> SoftRobotsBaseConstraint::getLambdaMax() const
+{
+    return m_lambdaMax;
+}
+
 SReal SoftRobotsBaseConstraint::getLambdaMin(const size_t i) const
 {
     return m_lambdaMin[i];
+}
+
+vector<double> SoftRobotsBaseConstraint::getLambdaMin() const
+{
+    return m_lambdaMin;
 }
 
 SReal SoftRobotsBaseConstraint::getLambdaEqual(const size_t i) const
@@ -132,6 +158,15 @@ SReal SoftRobotsBaseConstraint::getEpsilon() const
     return m_epsilon;
 }
 
+const sofa::core::objectmodel::Data<vector<double>>& SoftRobotsBaseConstraint::getLambda() const
+{
+    return d_lambda;
+}
+
+const sofa::core::objectmodel::Data<vector<double>>& SoftRobotsBaseConstraint::getDelta() const
+{
+    return d_delta;
+}
 
 unsigned int SoftRobotsBaseConstraint::getNbLines() const
 {
@@ -147,6 +182,25 @@ void SoftRobotsBaseConstraint::storeResults(vector<double>& lambda, vector<doubl
 void SoftRobotsBaseConstraint::storeResults(vector<double> &delta)
 {
     SOFA_UNUSED(delta);
+}
+
+void SoftRobotsBaseConstraint::resizeConstraints(const sofa::Size& size)
+{
+    m_nbLines = size;
+
+    m_lambdaInit.resize(size);
+    m_lambdaMax.resize(size);
+    m_lambdaMin.resize(size);
+    m_lambdaEqual.resize(size);
+
+    m_deltaMax.resize(size);
+    m_deltaMin.resize(size);
+    m_deltaEqual.resize(size);
+
+    auto delta = sofa::helper::getWriteAccessor(d_delta);
+    delta.resize(size, 0);
+    auto lambda = sofa::helper::getWriteAccessor(d_lambda);
+    lambda.resize(size, 0);
 }
 
 } // namespaces

--- a/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.h
+++ b/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.h
@@ -88,9 +88,11 @@ public:
 
     /// Accessor to maximum value of delta
     SReal getDeltaMax(const size_t i) const;
+    vector<double> getDeltaMax() const;
 
     /// Accessor to minimum value of delta
     SReal getDeltaMin(const size_t i) const;
+    vector<double> getDeltaMin() const;
 
     /// Accessor to equal constraint value of delta
     SReal getDeltaEqual(const size_t i) const;
@@ -98,9 +100,11 @@ public:
 
     /// Accessor to maximum value of lambda
     SReal getLambdaMax(const size_t i) const;
+    vector<double> getLambdaMax() const;
 
     /// Accessor to maximum value of lambda
     SReal getLambdaMin(const size_t i) const;
+    vector<double> getLambdaMin() const;
 
     /// Accessor to equal constraint value of lambda
     SReal getLambdaEqual(const size_t i) const;
@@ -113,18 +117,24 @@ public:
     SReal getEpsilon() const;
 
 
+    /// Accessor to lambda
+    const sofa::core::objectmodel::Data<vector<double>>& getLambda() const;
+
+    /// Accessor to delta
+    const sofa::core::objectmodel::Data<vector<double>>& getDelta() const;
+
 
     /// Accessor to nbLines value
     unsigned int getNbLines() const;
 
-    /// Allows the constraint to access to the results. Called from QPInverseProblemSolver.
-    virtual void storeResults(sofa::type::vector<double> &lambda, sofa::type::vector<double> &delta);
 
-    virtual void storeResults(sofa::type::vector<double> &delta);
+    /// Allows the constraint to access the results. Called from QPInverseProblemSolver.
+    virtual void storeResults(vector<double> &lambda, vector<double> &delta);
+    virtual void storeResults(vector<double> &delta);
 
-    virtual sofa::type::vector<std::string> getBaseConstraintIdentifiers() override final
+    virtual vector<std::string> getBaseConstraintIdentifiers() override final
     {
-        sofa::type::vector<std::string> ids = getSoftRobotsConstraintIdentifiers();
+        vector<std::string> ids = getSoftRobotsConstraintIdentifiers();
         ids.push_back("SoftRobots");
         return ids;
     }
@@ -135,7 +145,11 @@ protected:
 
     ~SoftRobotsBaseConstraint() override {}
 
-    virtual sofa::type::vector<std::string> getSoftRobotsConstraintIdentifiers(){ return {}; }
+    virtual vector<std::string> getSoftRobotsConstraintIdentifiers(){ return {}; }
+    void resizeConstraints(const sofa::Size& size);
+
+    sofa::core::objectmodel::Data<vector<double>> d_lambda;
+    sofa::core::objectmodel::Data<vector<double>> d_delta;
 
     unsigned int m_nbLines; ///< Constraint nbLines in the constraints matrix
 

--- a/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.h
+++ b/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.h
@@ -127,6 +127,12 @@ public:
     /// Accessor to nbLines value
     unsigned int getNbLines() const;
 
+    /// By default, the data d_lambda is described as a force. Depending on the constraint, this can change (e.g., to pressure)
+    void setLambdaDescription(const std::string& name, const std::string& help);
+
+    /// By default, the data d_delta is described as a displacement. Depending on the constraint, this can change (e.g., to volume growth)
+    void setDeltaDescription(const std::string& name, const std::string& help);
+
 
     /// Allows the constraint to access the results. Called from QPInverseProblemSolver.
     virtual void storeResults(vector<double> &lambda, vector<double> &delta);

--- a/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.h
+++ b/src/SoftRobots/component/behavior/SoftRobotsBaseConstraint.h
@@ -128,10 +128,14 @@ public:
     unsigned int getNbLines() const;
 
     /// By default, the data d_lambda is described as a force. Depending on the constraint, this can change (e.g., to pressure)
-    void setLambdaDescription(const std::string& name, const std::string& help);
+    void setLambdaNameAndHelp(const std::string& name, const std::string& help);
+    void setLambdaName(const std::string& name);
+    void setLambdaHelp(const std::string& help);
 
     /// By default, the data d_delta is described as a displacement. Depending on the constraint, this can change (e.g., to volume growth)
-    void setDeltaDescription(const std::string& name, const std::string& help);
+    void setDeltaNameAndHelp(const std::string& name, const std::string& help);
+    void setDeltaName(const std::string& name);
+    void setDeltaHelp(const std::string& help);
 
 
     /// Allows the constraint to access the results. Called from QPInverseProblemSolver.

--- a/src/SoftRobots/component/behavior/SoftRobotsConstraint.inl
+++ b/src/SoftRobots/component/behavior/SoftRobotsConstraint.inl
@@ -45,6 +45,10 @@ SoftRobotsConstraint<DataTypes>::SoftRobotsConstraint(sofa::core::behavior::Mech
                           "Use a negative value for infinite SoftRobotsConstraints") )
     , m_state(mm)
 {
+    d_lambda.setGroup("Output");
+    d_delta.setGroup("Output");
+    d_lambda.setReadOnly(true);
+    d_delta.setReadOnly(true);
 }
 
 template<class DataTypes>

--- a/src/SoftRobots/component/constraint/CableConstraint.cpp
+++ b/src/SoftRobots/component/constraint/CableConstraint.cpp
@@ -111,7 +111,7 @@ void CableForceConstraintResolution::resolution(int line, SReal** w, SReal* d, S
 
 void registerCableConstraint(sofa::core::ObjectFactory* factory)
 {
-    factory->registerObjects(ObjectRegistrationData("Simulate a cable.")
+    factory->registerObjects(ObjectRegistrationData("Lagrange multiplier approach to simulate a cable.")
     .add< CableConstraint<Vec3Types> >(true)
     .add< CableConstraint<Vec2Types> >());
 }

--- a/src/SoftRobots/component/constraint/CableConstraint.h
+++ b/src/SoftRobots/component/constraint/CableConstraint.h
@@ -131,15 +131,14 @@ public:
     using CableModel<DataTypes>::d_eqForce ;
     using CableModel<DataTypes>::d_maxForce ;
     using CableModel<DataTypes>::d_minForce ;
-    using CableModel<DataTypes>::d_displacement ;
     using CableModel<DataTypes>::d_componentState ;
     ///////////////////////////////////////////////////////////////////////////
 
 protected:
     //Input data
     Data<sofa::type::vector< Real > >       d_value;
-    Data<unsigned int>                  d_valueIndex;
-    Data<sofa::helper::OptionsGroup>          d_valueType;
+    Data<unsigned int>                      d_valueIndex;
+    Data<sofa::helper::OptionsGroup>        d_valueType;
                                         // displacement = the constraint will impose the displacement provided in data d_inputValue[d_iputIndex]
                                         // force = the constraint will impose the force provided in data d_inputValue[d_iputIndex]
 

--- a/src/SoftRobots/component/constraint/CableConstraint.h
+++ b/src/SoftRobots/component/constraint/CableConstraint.h
@@ -124,6 +124,7 @@ public:
     ////////////////////////////////////////////////////////////////
 
     ////////////////////////// Inherited attributes ////////////////////////////
+    using CableModel<DataTypes>::d_delta ;
     using CableModel<DataTypes>::d_maxDispVariation ;
     using CableModel<DataTypes>::d_maxPositiveDisplacement ;
     using CableModel<DataTypes>::d_maxNegativeDisplacement ;

--- a/src/SoftRobots/component/constraint/CableConstraint.inl
+++ b/src/SoftRobots/component/constraint/CableConstraint.inl
@@ -55,6 +55,7 @@ CableConstraint<DataTypes>::CableConstraint(MechanicalState* object)
 {
     d_eqDisplacement.setDisplayed(false);
     d_eqForce.setDisplayed(false);
+    this->d_lambda.setDisplayed(false);
 }
 
 template<class DataTypes>
@@ -130,7 +131,7 @@ void CableConstraint<DataTypes>::setUpDisplacementLimits(Real& imposedValue, Rea
 {
     if(d_maxDispVariation.isSet())
     {
-        Real displacement = d_displacement.getValue();
+        Real displacement = this->d_delta.getValue()[0];
         if(imposedValue > displacement && imposedValue-displacement>d_maxDispVariation.getValue())
             imposedValue = displacement+d_maxDispVariation.getValue();
 

--- a/src/SoftRobots/component/constraint/CableConstraint.inl
+++ b/src/SoftRobots/component/constraint/CableConstraint.inl
@@ -55,7 +55,6 @@ CableConstraint<DataTypes>::CableConstraint(MechanicalState* object)
 {
     d_eqDisplacement.setDisplayed(false);
     d_eqForce.setDisplayed(false);
-    this->d_lambda.setDisplayed(false);
 }
 
 template<class DataTypes>

--- a/src/SoftRobots/component/constraint/CableConstraint.inl
+++ b/src/SoftRobots/component/constraint/CableConstraint.inl
@@ -131,7 +131,7 @@ void CableConstraint<DataTypes>::setUpDisplacementLimits(Real& imposedValue, Rea
 {
     if(d_maxDispVariation.isSet())
     {
-        Real displacement = this->d_delta.getValue()[0];
+        Real displacement = d_delta.getValue()[0];
         if(imposedValue > displacement && imposedValue-displacement>d_maxDispVariation.getValue())
             imposedValue = displacement+d_maxDispVariation.getValue();
 

--- a/src/SoftRobots/component/constraint/JointConstraint.h
+++ b/src/SoftRobots/component/constraint/JointConstraint.h
@@ -147,6 +147,8 @@ protected:
     using SoftRobotsConstraint<DataTypes>::d_constraintIndex ;
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
     using SoftRobotsConstraint<DataTypes>::d_componentState ;
+    using SoftRobotsConstraint<DataTypes>::d_delta ;
+    using SoftRobotsConstraint<DataTypes>::d_lambda ;
     ////////////////////////////////////////////////////////////////////////////
 
     //Input data

--- a/src/SoftRobots/component/constraint/JointConstraint.h
+++ b/src/SoftRobots/component/constraint/JointConstraint.h
@@ -152,14 +152,16 @@ protected:
     //Input data
     sofa::Data<unsigned int>       d_index; ///< indice of considered node
 
-    sofa::Data<double>                d_force; ///< force applied on the points
-    sofa::Data<double>                d_displacement; ///< displacement of the points
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_lambda instead.")
+    sofa::Data<double>             d_force; ///< force applied on the points
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_delta instead.")
+    sofa::Data<double>             d_displacement; ///< displacement of the points
 
-    sofa::Data<double>                  d_maxForce; ///< maximum force applied on the points
-    sofa::Data<double>                  d_minForce; ///< minimum force applied on the points
+    sofa::Data<double>             d_maxForce; ///< maximum force applied on the points
+    sofa::Data<double>             d_minForce; ///< minimum force applied on the points
     
-    sofa::Data<double>                  d_maxDisplacement; ///< maximum displacement of the points
-    sofa::Data<double>                  d_minDisplacement; ///< minimum displacement of the points
+    sofa::Data<double>             d_maxDisplacement; ///< maximum displacement of the points
+    sofa::Data<double>             d_minDisplacement; ///< minimum displacement of the points
 
     sofa::Data<double> d_value;
     sofa::Data<sofa::helper::OptionsGroup>  d_valueType;

--- a/src/SoftRobots/component/constraint/JointConstraint.inl
+++ b/src/SoftRobots/component/constraint/JointConstraint.inl
@@ -211,8 +211,8 @@ void JointConstraint<DataTypes>::storeLambda(const ConstraintParams* cParams,
     if(d_componentState.getValue() != ComponentState::Valid)
         return ;
 
-    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
-    auto d = sofa::helper::getWriteAccessor(this->d_delta);
+    auto l = sofa::helper::getWriteAccessor(d_lambda);
+    auto d = sofa::helper::getWriteAccessor(d_delta);
 
     // Update joint effort
     l[0] = lambda->element(d_constraintIndex.getValue());

--- a/src/SoftRobots/component/constraint/JointConstraint.inl
+++ b/src/SoftRobots/component/constraint/JointConstraint.inl
@@ -46,12 +46,6 @@ JointConstraint<DataTypes>::JointConstraint(MechanicalState* object)
                           "Index of the node subjected to the force. \n"
                           "If no index given, first node of mechanical context considered."))
 
-    , d_force(initData(&d_force,double(0.0), "force",
-                                         "Output force. Warning: to get the actual force you should divide this value by dt."))
-
-    , d_displacement(initData(&d_displacement,double(0.0), "displacement",
-                          "Output displacement compared to the initial position."))
-
     , d_maxForce(initData(&d_maxForce, "maxForce",
                           "Maximum force allowed. \n"
                           "If unspecified no maximum value will be considered."))
@@ -76,8 +70,6 @@ JointConstraint<DataTypes>::JointConstraint(MechanicalState* object)
                                           "force = the constraint will impose the force provided in data value[valueIndex] \n"
                                           "If unspecified, the default value is displacement"))
 {
-    d_force.setReadOnly(true);
-    d_displacement.setReadOnly(true);
 }
 
 template<class DataTypes>
@@ -123,9 +115,6 @@ void JointConstraint<DataTypes>::internalInit()
 {
     ReadAccessor<sofa::Data<VecCoord> > positions = m_state->readPositions();
     m_initDisplacement = positions[d_index.getValue()][0];
-    d_displacement.setValue(0);
-    d_force.setValue(0);
-
 }
 
 template<class DataTypes>
@@ -208,7 +197,6 @@ void JointConstraint<DataTypes>::getConstraintResolution(const ConstraintParams*
 
         JointForceConstraintResolution *cr=  new JointForceConstraintResolution(imposedValue, minDisplacement, maxDisplacement);
         resTab[offset++] = cr;
-        
     }
 }
 
@@ -223,12 +211,17 @@ void JointConstraint<DataTypes>::storeLambda(const ConstraintParams* cParams,
     if(d_componentState.getValue() != ComponentState::Valid)
         return ;
 
+    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
+    auto d = sofa::helper::getWriteAccessor(this->d_delta);
+
     // Update joint effort
+    l[0] = lambda->element(d_constraintIndex.getValue());
     d_force.setValue(lambda->element(d_constraintIndex.getValue()));
 
     // Update joint displacement
     ReadAccessor<sofa::Data<VecCoord>> positions = m_state->readPositions();
     m_currentDisplacement = positions[d_index.getValue()][0];
+    d[0] = - m_initDisplacement + m_currentDisplacement;
     d_displacement.setValue(- m_initDisplacement + m_currentDisplacement);
 }
 

--- a/src/SoftRobots/component/constraint/PartialRigidificationConstraint.h
+++ b/src/SoftRobots/component/constraint/PartialRigidificationConstraint.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <SoftRobots/component/initSoftRobots.h>
-#include <sofa/core/behavior/Constraint.h>
+#include <sofa/core/behavior/LagrangianConstraint.h>
 #include <sofa/core/behavior/ConstraintResolution.h>
 #include <sofa/linearalgebra/BaseVector.h>
 
@@ -38,7 +38,7 @@ namespace softrobots::constraint
 
 using sofa::core::behavior::ConstraintResolution ;
 using sofa::core::ConstraintParams ;
-using sofa::core::behavior::Constraint ;
+using sofa::core::behavior::LagrangianConstraint ;
 using sofa::linearalgebra::BaseVector ;
 using sofa::type::Vec ;
 
@@ -49,11 +49,11 @@ public:
 };
 
 template< class DataTypes >
-class PartialRigidificationConstraint : public Constraint<DataTypes>
+class PartialRigidificationConstraint : public LagrangianConstraint<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(PartialRigidificationConstraint,DataTypes),
-               SOFA_TEMPLATE(sofa::core::behavior::Constraint,DataTypes));
+               SOFA_TEMPLATE(LagrangianConstraint,DataTypes));
 
     typedef typename DataTypes::VecCoord        VecCoord;
     typedef typename DataTypes::VecDeriv        VecDeriv;
@@ -98,7 +98,7 @@ protected:
 private:
 
     ////////////////////////// Inherited attributes ////////////////////////////
-    using Constraint<DataTypes>::mstate ;
+    using LagrangianConstraint<DataTypes>::mstate ;
     ////////////////////////////////////////////////////////////////////////////
 };
 

--- a/src/SoftRobots/component/constraint/PositionConstraint.cpp
+++ b/src/SoftRobots/component/constraint/PositionConstraint.cpp
@@ -110,7 +110,7 @@ void PositionForceConstraintResolution::resolution(int line, double** w, double*
 ////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
 void registerPositionConstraint(sofa::core::ObjectFactory* factory)
 {
-    factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate a Position.")
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Lagrange multiplier approach to apply force / displacement to points.")
     .add< PositionConstraint<Vec3Types> >(true)
     .add< PositionConstraint<Vec2Types> >()
     .add< PositionConstraint<Rigid3Types> >());

--- a/src/SoftRobots/component/constraint/PositionConstraint.h
+++ b/src/SoftRobots/component/constraint/PositionConstraint.h
@@ -140,7 +140,9 @@ public:
 
 protected:
     //Input data
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_lambda instead.")
     sofa::Data<double>                d_force; ///< force applied on the points
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_delta instead.")
     sofa::Data<double>                d_displacement; ///< displacement of the points
 
     sofa::Data<Real>                  d_maxForce; ///< maximum force applied on the points

--- a/src/SoftRobots/component/constraint/PositionConstraint.inl
+++ b/src/SoftRobots/component/constraint/PositionConstraint.inl
@@ -42,12 +42,6 @@ template<class DataTypes>
 PositionConstraint<DataTypes>::PositionConstraint(MechanicalState* object)
     : PositionModel<DataTypes>(object)
 
-    , d_force(initData(&d_force,double(0.0), "force",
-                                         "Output force. Warning: to get the actual force you should divide this value by dt."))
-
-    , d_displacement(initData(&d_displacement,double(0.0), "displacement",
-                          "Output displacement compared to the initial position."))
-
     , d_maxForce(initData(&d_maxForce, "maxForce",
                           "Maximum force allowed. \n"
                           "If unspecified no maximum value will be considered."))
@@ -76,10 +70,6 @@ PositionConstraint<DataTypes>::PositionConstraint(MechanicalState* object)
                                           "force = the constraint will impose the force provided in data value[valueIndex] \n"
                                           "If unspecified, the default value is displacement"))
 {
-    d_force.setGroup("Vector");
-    d_displacement.setGroup("Vector");
-    d_force.setReadOnly(true);
-    d_displacement.setReadOnly(true);
 }
 
 template<class DataTypes>
@@ -205,6 +195,9 @@ void PositionConstraint<DataTypes>::storeLambda(const ConstraintParams* cParams,
     if(d_componentState.getValue() != ComponentState::Valid)
         return ;
 
+    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
+
+    l[0] = lambda->element(d_constraintIndex.getValue());
     d_force.setValue(lambda->element(d_constraintIndex.getValue()));
 }
 

--- a/src/SoftRobots/component/constraint/SurfacePressureConstraint.cpp
+++ b/src/SoftRobots/component/constraint/SurfacePressureConstraint.cpp
@@ -112,8 +112,7 @@ void VolumeGrowthConstraintResolution::resolution(int line, SReal** w, SReal* d,
 ///////////////////////////////////////// FACTORY //////////////////////////////////////////////////
 void registerSurfacePressureConstraint(sofa::core::ObjectFactory* factory)
 {
-    factory->registerObjects(sofa::core::ObjectRegistrationData("This component constrains a model by applying "
-                                                          "pressure on surfaces (for example cavities)")
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Lagrange multiplier approach to apply pressure on surfaces (for example cavities)")
     .add< SurfacePressureConstraint<Vec3Types> >(true));
 }
 

--- a/src/SoftRobots/component/constraint/SurfacePressureConstraint.h
+++ b/src/SoftRobots/component/constraint/SurfacePressureConstraint.h
@@ -128,7 +128,6 @@ protected:
     vector<Real>                            m_initialValue;
 
     ////////////////////////// Inherited attributes ////////////////////////////
-    using SurfacePressureModel<DataTypes>::d_volumeGrowth ;
     using SurfacePressureModel<DataTypes>::d_maxVolumeGrowthVariation ;
     using SurfacePressureModel<DataTypes>::d_maxVolumeGrowth ;
     using SurfacePressureModel<DataTypes>::d_minVolumeGrowth ;
@@ -138,7 +137,6 @@ protected:
     using SurfacePressureModel<DataTypes>::d_minPressure ;
     using SurfacePressureModel<DataTypes>::d_maxPressureVariation;
     using SoftRobotsConstraint<DataTypes>::d_componentState;
-    using SurfacePressureModel<DataTypes>::d_pressure ;
     ////////////////////////////////////////////////////////////////////////////
 
 private:

--- a/src/SoftRobots/component/constraint/SurfacePressureConstraint.h
+++ b/src/SoftRobots/component/constraint/SurfacePressureConstraint.h
@@ -128,6 +128,7 @@ protected:
     vector<Real>                            m_initialValue;
 
     ////////////////////////// Inherited attributes ////////////////////////////
+    using SurfacePressureModel<DataTypes>::d_delta ;
     using SurfacePressureModel<DataTypes>::d_maxVolumeGrowthVariation ;
     using SurfacePressureModel<DataTypes>::d_maxVolumeGrowth ;
     using SurfacePressureModel<DataTypes>::d_minVolumeGrowth ;

--- a/src/SoftRobots/component/constraint/SurfacePressureConstraint.inl
+++ b/src/SoftRobots/component/constraint/SurfacePressureConstraint.inl
@@ -145,7 +145,7 @@ void SurfacePressureConstraint<DataTypes>::setUpVolumeLimits(Real& imposedValue,
 {
     if(d_maxVolumeGrowthVariation.isSet())
     {
-        double volumeGrowth = this->d_delta.getValue()[0];
+        double volumeGrowth = d_delta.getValue()[0];
         if(imposedValue > volumeGrowth && imposedValue-volumeGrowth>d_maxVolumeGrowthVariation.getValue())
             imposedValue = volumeGrowth+d_maxVolumeGrowthVariation.getValue();
 

--- a/src/SoftRobots/component/constraint/SurfacePressureConstraint.inl
+++ b/src/SoftRobots/component/constraint/SurfacePressureConstraint.inl
@@ -145,7 +145,7 @@ void SurfacePressureConstraint<DataTypes>::setUpVolumeLimits(Real& imposedValue,
 {
     if(d_maxVolumeGrowthVariation.isSet())
     {
-        double volumeGrowth = d_volumeGrowth.getValue();
+        double volumeGrowth = this->d_delta.getValue()[0];
         if(imposedValue > volumeGrowth && imposedValue-volumeGrowth>d_maxVolumeGrowthVariation.getValue())
             imposedValue = volumeGrowth+d_maxVolumeGrowthVariation.getValue();
 
@@ -172,7 +172,7 @@ void SurfacePressureConstraint<DataTypes>::setUpPressureLimits(Real& imposedValu
 {
     if (d_maxPressureVariation.isSet())
     {
-        double pressure = this->d_pressure.getValue();
+        double pressure = this->d_lambda.getValue()[0];
         if (imposedValue > pressure && imposedValue - pressure > d_maxPressureVariation.getValue())
             imposedValue = pressure + d_maxPressureVariation.getValue();
 

--- a/src/SoftRobots/component/constraint/UnilateralPlaneConstraint.h
+++ b/src/SoftRobots/component/constraint/UnilateralPlaneConstraint.h
@@ -123,7 +123,7 @@ protected:
     ////////////////////////////////////////////////////////////////////////////
 
     sofa::Data<Vec<4,unsigned int>>   d_indices;
-    sofa::Data<bool>         d_flipNormal;
+    sofa::Data<bool>                  d_flipNormal;
 
     void drawPoints(const VisualParams* vparams);
     void drawTriangles(const VisualParams* vparams);

--- a/src/SoftRobots/component/constraint/model/AffineFunctionModel.h
+++ b/src/SoftRobots/component/constraint/model/AffineFunctionModel.h
@@ -117,6 +117,8 @@ protected:
     SReal getAffineFunctionValue(const VecCoord &positions);
 
     ////////////////////////// Inherited attributes ////////////////////////////
+    using SoftRobotsConstraint<DataTypes>::d_delta ;
+    using SoftRobotsConstraint<DataTypes>::d_lambda ;
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
     using SoftRobotsConstraint<DataTypes>::d_constraintIndex ;
     using SoftRobotsConstraint<DataTypes>::m_state ;

--- a/src/SoftRobots/component/constraint/model/AffineFunctionModel.h
+++ b/src/SoftRobots/component/constraint/model/AffineFunctionModel.h
@@ -31,6 +31,7 @@
 #include <sofa/defaulttype/RigidTypes.h>
 
 #include <SoftRobots/component/behavior/SoftRobotsConstraint.h>
+#include <sofa/core/objectmodel/lifecycle/DeprecatedData.h>
 
 namespace softrobots::constraint
 {
@@ -63,8 +64,8 @@ public:
     typedef typename sofa::core::behavior::MechanicalState<DataTypes> MechanicalState;
 
     typedef typename DataTypes::MatrixDeriv::RowIterator MatrixDerivRowIterator;
-    typedef Data<VecCoord>		DataVecCoord;
-    typedef Data<VecDeriv>		DataVecDeriv;
+    typedef Data<VecCoord>		 DataVecCoord;
+    typedef Data<VecDeriv>		 DataVecDeriv;
     typedef Data<MatrixDeriv>    DataMatrixDeriv;
     typedef sofa::type::vector<unsigned int> SetIndexArray;
 
@@ -105,8 +106,11 @@ protected:
     Data<Real>                  d_initFunctionValue;
 	Data<Real>                  d_functionValue;
 
-    Data<double>                d_force;
-    Data<double>                d_displacement;
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_lambda instead.")
+    Data<double> d_force;
+
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_delta instead.")
+    Data<double> d_displacement;
 
 protected:
 

--- a/src/SoftRobots/component/constraint/model/AffineFunctionModel.inl
+++ b/src/SoftRobots/component/constraint/model/AffineFunctionModel.inl
@@ -51,12 +51,6 @@ AffineFunctionModel<DataTypes>::AffineFunctionModel(MechanicalState* object)
 	, d_initFunctionValue(initData(&d_initFunctionValue, Real(0.0),"initialFunctionValue", "Set to be the function value in the rest positions."))
 
     , d_functionValue(initData(&d_functionValue, Real(0.0), "functionValue","Function value."))
-
-    , d_force(initData(&d_force,double(0.0), "force", "Output force. Warning: to get the actual force you should divide this value by dt."))
-
-    , d_displacement(initData(&d_displacement,double(0.0), "displacement",
-                          "Output function value compared to the initial function value."))
-
 {
     setUpData();
 }
@@ -70,9 +64,6 @@ template<class DataTypes>
 void AffineFunctionModel<DataTypes>::setUpData()
 {
     d_initFunctionValue.setReadOnly(true);
-
-    d_force.setGroup("Output");
-    d_displacement.setGroup("Output");
 }
 
 template<class DataTypes>
@@ -240,9 +231,14 @@ void AffineFunctionModel<DataTypes>::storeLambda(const ConstraintParams* cParams
     if(d_componentState.getValue() != ComponentState::Valid)
             return ;
     
+    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
+    auto d = sofa::helper::getWriteAccessor(this->d_delta);
+
+    l[0] = lambda->element(d_constraintIndex.getValue());
     d_force.setValue(lambda->element(d_constraintIndex.getValue()));
 
     //Note: this is one step behind
+    d[0] = d_functionValue.getValue();
     d_displacement.setValue(d_functionValue.getValue());
 }
 

--- a/src/SoftRobots/component/constraint/model/AffineFunctionModel.inl
+++ b/src/SoftRobots/component/constraint/model/AffineFunctionModel.inl
@@ -231,8 +231,8 @@ void AffineFunctionModel<DataTypes>::storeLambda(const ConstraintParams* cParams
     if(d_componentState.getValue() != ComponentState::Valid)
             return ;
     
-    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
-    auto d = sofa::helper::getWriteAccessor(this->d_delta);
+    auto l = sofa::helper::getWriteAccessor(d_lambda);
+    auto d = sofa::helper::getWriteAccessor(d_delta);
 
     l[0] = lambda->element(d_constraintIndex.getValue());
     d_force.setValue(lambda->element(d_constraintIndex.getValue()));

--- a/src/SoftRobots/component/constraint/model/CableModel.h
+++ b/src/SoftRobots/component/constraint/model/CableModel.h
@@ -148,7 +148,7 @@ protected:
     Data<bool>                  d_drawPoints; ///< to draw center points of cable
     Data<bool>                  d_drawPulledAreas; ///< to draw points in cable area effect
 
-    Data<sofa::type::RGBAColor>       d_color;
+    Data<sofa::type::RGBAColor> d_color;
 
     bool                        m_hasSlidingPoint;
 
@@ -160,6 +160,8 @@ protected:
     /// Bring m_state in the current lookup context.
     /// otherwise any access to the base::attribute would require
     /// using the "this->" approach.
+    using SoftRobotsConstraint<DataTypes>::d_delta ;
+    using SoftRobotsConstraint<DataTypes>::d_lambda ;
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
     using SoftRobotsConstraint<DataTypes>::d_constraintIndex ;
     using SoftRobotsConstraint<DataTypes>::m_state ;

--- a/src/SoftRobots/component/constraint/model/CableModel.h
+++ b/src/SoftRobots/component/constraint/model/CableModel.h
@@ -127,11 +127,13 @@ protected:
     sofa::type::vector<SetIndexArray> m_areaIndices;
     sofa::type::vector<sofa::type::vector<Real>> m_ratios;
 
-    sofa::type::vector<Real> m_alphaBarycentric;
-    sofa::type::vector<Real> m_betaBarycentric;
+    sofa::type::vector<Real>     m_alphaBarycentric;
+    sofa::type::vector<Real>     m_betaBarycentric;
     sofa::type::vector<Triangle> m_closestTriangle;
 
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_lambda instead.")
     Data<double>                d_force; ///< pulling force applied on the cable
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_delta instead.")
     Data<double>                d_displacement; ///< displacement of the cable
 
     Data<Real>                  d_maxForce; ///< maximum pulling force applied on the cable

--- a/src/SoftRobots/component/constraint/model/CableModel.inl
+++ b/src/SoftRobots/component/constraint/model/CableModel.inl
@@ -89,12 +89,6 @@ CableModel<DataTypes>::CableModel(MechanicalState* object)
     , l_surfaceTopology(initLink("surfaceTopology", "Link to the topology container of the surface on which the cable is attached. \n"
                                                     "Used only with sphere and geodesic methods."))
 
-    , d_force(initData(&d_force,double(0.0), "force",
-                                         "Output force. Warning: to get the actual force you should divide this value by dt."))
-
-    , d_displacement(initData(&d_displacement,double(0.0), "displacement",
-                          "Output displacement compared to the initial cable length."))
-
     , d_maxForce(initData(&d_maxForce, "maxForce",
                           "Maximum force of the actuator. \n"
                           "If unspecified no maximum value will be considered."))
@@ -136,7 +130,6 @@ CableModel<DataTypes>::CableModel(MechanicalState* object)
 
     , d_color(initData(&d_color,RGBAColor(0.4f,0.4f,0.4f,1.f), "color",
                           "Color of the string."))
-
 {
     setUpData();
 }
@@ -150,11 +143,6 @@ template<class DataTypes>
 void CableModel<DataTypes>::setUpData()
 {
     d_cableLength.setReadOnly(true);
-
-    d_force.setGroup("Vector");
-    d_displacement.setGroup("Vector");
-    d_force.setReadOnly(true);
-    d_displacement.setReadOnly(true);
 
     d_drawPullPoint.setGroup("Visualization");
     d_drawPoints.setGroup("Visualization");
@@ -204,11 +192,8 @@ template<class DataTypes>
 void CableModel<DataTypes>::bwdInit()
 {
     if(d_componentState.getValue() != ComponentState::Valid)
-    {
         return;
-    }
             
-
     // The initial length of the cable is set or computed in bwdInit so the mapping (if there is any)
     // will be considered
 
@@ -223,7 +208,6 @@ void CableModel<DataTypes>::bwdInit()
         d_cableInitialLength.setValue(initialCableLength);
     }
     d_cableLength.setValue(cableLength);
-        
 }
 
 
@@ -231,9 +215,8 @@ template<class DataTypes>
 void CableModel<DataTypes>::reinit()
 {
     if(d_componentState.getValue() != ComponentState::Valid)
-    {
-            return ;
-    }
+        return;
+
     internalInit();
 }
 
@@ -242,12 +225,10 @@ template<class DataTypes>
 void CableModel<DataTypes>::reset()
 {
     if(d_componentState.getValue() != ComponentState::Valid)
-    {
-        return ;
-    }
+        return;
+
     d_cableLength.setValue(d_cableInitialLength.getValue());
 }
-
 
 
 template<class DataTypes>
@@ -442,8 +423,6 @@ void CableModel<DataTypes>::computePointsActionArea()
             // Compute barycentric coordinates for visualization purposes
             computeBarycentric(closestTriangle, closestProjectionOnTriangle, m_alphaBarycentric[i], m_betaBarycentric[i]);
             m_closestTriangle[i] = closestTriangle;
-
-
         }
         else
         {
@@ -578,7 +557,7 @@ void CableModel<DataTypes>::computeBarycentric(const Triangle& triangle, const C
     getPositionFromTopology(v1, triangle[1]);
     getPositionFromTopology(v2, triangle[2]); 
 
-   // Solving with Cramer's rule
+    // Solving with Cramer's rule
     Coord e0 = v1 - v0; 
     Coord e1 = v2 - v0;
     Coord e2 = p - v0;
@@ -629,9 +608,7 @@ template<class DataTypes>
 void CableModel<DataTypes>::buildConstraintMatrix(const ConstraintParams* cParams, DataMatrixDeriv &cMatrix, unsigned int &cIndex, const DataVecCoord &x)
 {
     if(d_componentState.getValue() != ComponentState::Valid)
-    {
-            return ;
-    }
+        return;
 
     SOFA_UNUSED(cParams);
 
@@ -648,7 +625,6 @@ void CableModel<DataTypes>::buildConstraintMatrix(const ConstraintParams* cParam
 
     if(!m_hasSlidingPoint)
     {
-
         if ( d_hasPullPoint.getValue())
         {
             Deriv direction = DataTypes::coordDifference(d_pullPoint.getValue(),positions[d_indices.getValue()[0]]);
@@ -758,9 +734,7 @@ void CableModel<DataTypes>::buildConstraintMatrix(const ConstraintParams* cParam
                 {
                     for(unsigned int j=0; j<m_areaIndices[i].size(); j++)
                         rowIterator.setCol(m_areaIndices[i][j], slidingDirection*m_ratios[i][j]);
-                }
-
-                
+                }   
             }
             else // end point of the cable
             {
@@ -795,9 +769,7 @@ void CableModel<DataTypes>::getConstraintViolation(const ConstraintParams* cPara
                                                    const BaseVector *Jdx)
 {
     if(d_componentState.getValue() != ComponentState::Valid)
-    {
-            return ;
-    }
+        return;
 
     SOFA_UNUSED(cParams);
 
@@ -815,11 +787,14 @@ void CableModel<DataTypes>::storeLambda(const ConstraintParams* cParams,
     SOFA_UNUSED(res);
     SOFA_UNUSED(cParams);
 
-    if(d_componentState.getValue() != ComponentState::Valid)
-    {
-            return ;
-    }
 
+    if(d_componentState.getValue() != ComponentState::Valid)
+        return;
+
+    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
+    auto d = sofa::helper::getWriteAccessor(this->d_delta);
+
+    l[0] = lambda->element(d_constraintIndex.getValue());
     d_force.setValue(lambda->element(d_constraintIndex.getValue()));
 
     // Compute actual cable length and displacement from updated positions of mechanical
@@ -827,6 +802,7 @@ void CableModel<DataTypes>::storeLambda(const ConstraintParams* cParams,
     //            so the value of delta is one step behind...
     //ReadAccessor<Data<VecCoord>> positions = m_state->readPositions();
     //d_cableLength.setValue(getCableLength(positions.ref()));
+    d[0] = d_cableInitialLength.getValue()-d_cableLength.getValue();
     d_displacement.setValue(d_cableInitialLength.getValue()-d_cableLength.getValue());
 }
 
@@ -834,9 +810,7 @@ template<class DataTypes>
 void CableModel<DataTypes>::draw(const VisualParams* vparams)
 {
     if(d_componentState.getValue() != ComponentState::Valid)
-    {
-            return ;
-    }
+        return;
 
     if (!vparams->displayFlags().getShowInteractionForceFields()) 
     {
@@ -904,7 +878,6 @@ void CableModel<DataTypes>::drawPoints(const VisualParams* vparams)
         }
     }
         
-
     vparams->drawTool()->drawPoints(points, 15, RGBAColor::red());
 }
 
@@ -964,12 +937,14 @@ void CableModel<DataTypes>::drawPulledAreas(const VisualParams* vparams)
     ReadAccessor<Data<vector<Coord>>> positions = m_state->readPositions();
 
     for(unsigned int i=0; i<m_areaIndices.size(); i++)
+    {
         for(unsigned int j=0; j<m_areaIndices[i].size(); j++)
         {
             vector<Vec3> point(1);
             point[0] = positions[m_areaIndices[i][j]];
             vparams->drawTool()->drawPoints(point, 40.f * m_ratios[i][j], RGBAColor::yellow());
         }
+    }
 }
 
 

--- a/src/SoftRobots/component/constraint/model/CableModel.inl
+++ b/src/SoftRobots/component/constraint/model/CableModel.inl
@@ -801,7 +801,7 @@ void CableModel<DataTypes>::storeLambda(const ConstraintParams* cParams,
     // Eulalie.C: For now the position of the mechanical state is not up to date when storeLambda() is called
     //            so the value of delta is one step behind...
     //ReadAccessor<Data<VecCoord>> positions = m_state->readPositions();
-    //d_cableLength.setValue(getCableLength(positions.ref()));
+    //d[0] = getCableLength(positions.ref());
     d[0] = d_cableInitialLength.getValue()-d_cableLength.getValue();
     d_displacement.setValue(d_cableInitialLength.getValue()-d_cableLength.getValue());
 }

--- a/src/SoftRobots/component/constraint/model/CableModel.inl
+++ b/src/SoftRobots/component/constraint/model/CableModel.inl
@@ -791,8 +791,8 @@ void CableModel<DataTypes>::storeLambda(const ConstraintParams* cParams,
     if(d_componentState.getValue() != ComponentState::Valid)
         return;
 
-    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
-    auto d = sofa::helper::getWriteAccessor(this->d_delta);
+    auto l = sofa::helper::getWriteAccessor(d_lambda);
+    auto d = sofa::helper::getWriteAccessor(d_delta);
 
     l[0] = lambda->element(d_constraintIndex.getValue());
     d_force.setValue(lambda->element(d_constraintIndex.getValue()));

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -94,6 +94,7 @@ protected:
     using SoftRobotsConstraint<DataTypes>::d_constraintIndex ;
     using SoftRobotsConstraint<DataTypes>::d_componentState ;
     using SoftRobotsConstraint<DataTypes>::m_state ;
+    using SoftRobotsConstraint<DataTypes>::d_delta ;
     ////////////////////////////////////////////////////////////////////////////
 
     void setDefaultDirections();

--- a/src/SoftRobots/component/constraint/model/PositionModel.h
+++ b/src/SoftRobots/component/constraint/model/PositionModel.h
@@ -88,7 +88,6 @@ protected:
     sofa::Data<sofa::type::vector<Real>>              d_weight;
     sofa::Data<VecDeriv>                              d_directions;
     sofa::Data<Vec<Deriv::total_size, bool>>          d_useDirections;
-    sofa::Data<sofa::type::vector<Real>>              d_delta;
 
     ////////////////////////// Inherited attributes ////////////////////////////
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
@@ -107,7 +106,6 @@ private:
     void checkIndicesRegardingState();
     void setIndicesDefaultValue();
     void resizeIndicesRegardingState();
-
 
 };
 

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -64,6 +64,9 @@ PositionModel<DataTypes>::PositionModel(MechanicalState* object)
                               "which you want to solve the position. If unspecified, the default \n"
                               "values are all true."))
 {
+    this->d_delta.setHelp("Distance to target.");
+    this->d_delta.setName("delta");
+
     this->addUpdateCallback("updateWeight", {&d_weight}, [this](const sofa::core::DataTracker& t)
                             {
                                 SOFA_UNUSED(t);

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -64,7 +64,7 @@ PositionModel<DataTypes>::PositionModel(MechanicalState* object)
                               "which you want to solve the position. If unspecified, the default \n"
                               "values are all true."))
 {
-    this->setDeltaDescription("delta", "Distance to target.");
+    this->setDeltaNameAndHelp("delta", "Distance to target.");
 
     this->addUpdateCallback("updateWeight", {&d_weight}, [this](const sofa::core::DataTracker& t)
                             {

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -64,9 +64,7 @@ PositionModel<DataTypes>::PositionModel(MechanicalState* object)
                               "which you want to solve the position. If unspecified, the default \n"
                               "values are all true."))
 {
-    this->addAlias(&d_delta, "delta");
-    d_delta.setHelp("Distance to target.");
-    d_delta.setName("delta");
+    this->setDeltaDescription("delta", "Distance to target.");
 
     this->addUpdateCallback("updateWeight", {&d_weight}, [this](const sofa::core::DataTracker& t)
                             {

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -63,11 +63,7 @@ PositionModel<DataTypes>::PositionModel(MechanicalState* object)
                               "The parameter useDirections allows to select the directions in \n"
                               "which you want to solve the position. If unspecified, the default \n"
                               "values are all true."))
-
-    , d_delta(initData(&d_delta, "delta","Distance to target"))
 {
-    d_delta.setReadOnly(true);
-
     this->addUpdateCallback("updateWeight", {&d_weight}, [this](const sofa::core::DataTracker& t)
                             {
                                 SOFA_UNUSED(t);
@@ -187,8 +183,6 @@ void PositionModel<DataTypes>::checkIndicesRegardingState()
 }
 
 
-
-
 template<class DataTypes>
 void PositionModel<DataTypes>::setIndicesDefaultValue()
 {
@@ -196,13 +190,13 @@ void PositionModel<DataTypes>::setIndicesDefaultValue()
     defaultIndices.resize(1);
 }
 
+
 template<class DataTypes>
 void PositionModel<DataTypes>::resizeIndicesRegardingState()
 {
     WriteAccessor<sofa::Data<vector<unsigned int>>> indices = d_indices;
     indices.resize(m_state->getSize());
 }
-
 
 
 template<class DataTypes>
@@ -253,7 +247,7 @@ void PositionModel<DataTypes>::storeResults(vector<double> &delta)
     if(d_componentState.getValue() != ComponentState::Valid)
         return;
 
-    d_delta.setValue(delta);
+    this->d_delta.setValue(delta);
 }
 
 

--- a/src/SoftRobots/component/constraint/model/PositionModel.inl
+++ b/src/SoftRobots/component/constraint/model/PositionModel.inl
@@ -64,8 +64,9 @@ PositionModel<DataTypes>::PositionModel(MechanicalState* object)
                               "which you want to solve the position. If unspecified, the default \n"
                               "values are all true."))
 {
-    this->d_delta.setHelp("Distance to target.");
-    this->d_delta.setName("delta");
+    this->addAlias(&d_delta, "delta");
+    d_delta.setHelp("Distance to target.");
+    d_delta.setName("delta");
 
     this->addUpdateCallback("updateWeight", {&d_weight}, [this](const sofa::core::DataTracker& t)
                             {
@@ -250,7 +251,7 @@ void PositionModel<DataTypes>::storeResults(vector<double> &delta)
     if(d_componentState.getValue() != ComponentState::Valid)
         return;
 
-    this->d_delta.setValue(delta);
+    d_delta.setValue(delta);
 }
 
 

--- a/src/SoftRobots/component/constraint/model/SurfacePressureModel.h
+++ b/src/SoftRobots/component/constraint/model/SurfacePressureModel.h
@@ -115,12 +115,15 @@ protected:
 
     SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_lambda instead.")
     Data<double>                        d_pressure;
+
     Data<Real>                          d_maxPressure;
     Data<Real>                          d_minPressure;
     Data<Real>                          d_eqPressure;
     Data<Real>                          d_maxPressureVariation;
+
     SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_delta instead.")
     Data<double>                        d_volumeGrowth;
+
     Data<Real>                          d_maxVolumeGrowth;
     Data<Real>                          d_minVolumeGrowth;
     Data<Real>                          d_eqVolumeGrowth;

--- a/src/SoftRobots/component/constraint/model/SurfacePressureModel.h
+++ b/src/SoftRobots/component/constraint/model/SurfacePressureModel.h
@@ -147,6 +147,8 @@ protected:
     using SoftRobotsConstraint<DataTypes>::m_nbLines ;
     using SoftRobotsConstraint<DataTypes>::d_constraintIndex ;
     using SoftRobotsConstraint<DataTypes>::d_componentState ;
+    using SoftRobotsConstraint<DataTypes>::d_delta ;
+    using SoftRobotsConstraint<DataTypes>::d_lambda ;
     ////////////////////////////////////////////////////////////////////////////
 
 private:

--- a/src/SoftRobots/component/constraint/model/SurfacePressureModel.h
+++ b/src/SoftRobots/component/constraint/model/SurfacePressureModel.h
@@ -113,11 +113,13 @@ protected:
     Data<Real>                          d_cavityVolume;
     Data<bool>                          d_flipNormal;
 
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_lambda instead.")
     Data<double>                        d_pressure;
     Data<Real>                          d_maxPressure;
     Data<Real>                          d_minPressure;
     Data<Real>                          d_eqPressure;
     Data<Real>                          d_maxPressureVariation;
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06", "Use d_delta instead.")
     Data<double>                        d_volumeGrowth;
     Data<Real>                          d_maxVolumeGrowth;
     Data<Real>                          d_minVolumeGrowth;

--- a/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
+++ b/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
@@ -117,11 +117,13 @@ SurfacePressureModel<DataTypes>::SurfacePressureModel(MechanicalState* object)
 {
     setUpData();
 
-    this->d_lambda.setHelp("Pressure. Warning: to get the actual pressure you should divide this value by dt.");
-    this->d_delta.setHelp("Volume growth.");
+    this->addAlias(&d_delta, "volumeGrowth");
+    d_delta.setName("volumeGrowth");
+    d_delta.setHelp("Volume growth.");
 
-    this->d_lambda.setName("pressure");
-    this->d_delta.setName("volumeGrowth");
+    this->addAlias(&d_lambda, "pressure");
+    d_lambda.setName("pressure");
+    d_lambda.setHelp("Pressure. Warning: to get the actual pressure you should divide this value by dt.");
 }
 
 template<class DataTypes>
@@ -371,8 +373,8 @@ void SurfacePressureModel<DataTypes>::storeLambda(const ConstraintParams* cParam
     if(d_componentState.getValue() != ComponentState::Valid)
             return ;
 
-    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
-    auto d = sofa::helper::getWriteAccessor(this->d_delta);
+    auto l = sofa::helper::getWriteAccessor(d_lambda);
+    auto d = sofa::helper::getWriteAccessor(d_delta);
 
     l[0] = lambda->element(d_constraintIndex.getValue());
     d_pressure.setValue(lambda->element(d_constraintIndex.getValue()));

--- a/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
+++ b/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
@@ -117,8 +117,8 @@ SurfacePressureModel<DataTypes>::SurfacePressureModel(MechanicalState* object)
 {
     setUpData();
 
-    this->setLambdaDescription("pressure", "Pressure. Warning: to get the actual pressure you should divide this value by dt.");
-    this->setDeltaDescription("volumeGrowth", "Volume growth");
+    this->setLambdaNameAndHelp("pressure", "Pressure. Warning: to get the actual pressure you should divide this value by dt.");
+    this->setDeltaNameAndHelp("volumeGrowth", "Volume growth");
 }
 
 template<class DataTypes>

--- a/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
+++ b/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
@@ -117,13 +117,8 @@ SurfacePressureModel<DataTypes>::SurfacePressureModel(MechanicalState* object)
 {
     setUpData();
 
-    this->addAlias(&d_delta, "volumeGrowth");
-    d_delta.setName("volumeGrowth");
-    d_delta.setHelp("Volume growth.");
-
-    this->addAlias(&d_lambda, "pressure");
-    d_lambda.setName("pressure");
-    d_lambda.setHelp("Pressure. Warning: to get the actual pressure you should divide this value by dt.");
+    this->setLambdaDescription("pressure", "Pressure. Warning: to get the actual pressure you should divide this value by dt.");
+    this->setDeltaDescription("volumeGrowth", "Volume growth");
 }
 
 template<class DataTypes>

--- a/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
+++ b/src/SoftRobots/component/constraint/model/SurfacePressureModel.inl
@@ -70,10 +70,6 @@ SurfacePressureModel<DataTypes>::SurfacePressureModel(MechanicalState* object)
                                "If a positive pressure acts like a depressurization, try to set \n"
                                "flipNormal to true."))
 
-    , d_pressure(initData(&d_pressure, double(0.0), "pressure",
-                             "Output pressure. Warning: to get the actual pressure you should divide this value by dt."))
-
-
     , d_maxPressure(initData(&d_maxPressure, "maxPressure",
                              "Maximum pressure allowed for actuation. If no value is set by user, no \n"
                              "maximum pressure constraint will be considered."))
@@ -90,9 +86,6 @@ SurfacePressureModel<DataTypes>::SurfacePressureModel(MechanicalState* object)
     , d_maxPressureVariation(initData(&d_maxPressureVariation, "maxPressureVariation",
                             "Maximum pressure variation allowed for actuation. If no value is set by user, no \n"
                             "maximum will be considered."))
-
-    , d_volumeGrowth(initData(&d_volumeGrowth, double(0.0), "volumeGrowth",
-                             "Output volume growth."))
 
     , d_maxVolumeGrowth(initData(&d_maxVolumeGrowth, "maxVolumeGrowth",
                              "Maximum volume growth allowed for actuation. If no value is set by user, no \n"
@@ -123,6 +116,12 @@ SurfacePressureModel<DataTypes>::SurfacePressureModel(MechanicalState* object)
 
 {
     setUpData();
+
+    this->d_lambda.setHelp("Pressure. Warning: to get the actual pressure you should divide this value by dt.");
+    this->d_delta.setHelp("Volume growth.");
+
+    this->d_lambda.setName("pressure");
+    this->d_delta.setName("volumeGrowth");
 }
 
 template<class DataTypes>
@@ -135,11 +134,6 @@ void SurfacePressureModel<DataTypes>::setUpData()
 {
     d_cavityVolume.setReadOnly(true);
     d_initialCavityVolume.setReadOnly(true);
-
-    d_pressure.setGroup("Vector");
-    d_volumeGrowth.setGroup("Vector");
-    d_pressure.setReadOnly(true);
-    d_volumeGrowth.setReadOnly(true);
 
     d_drawPressure.setGroup("Visualization");
     d_drawScale.setGroup("Visualization");
@@ -193,8 +187,6 @@ void SurfacePressureModel<DataTypes>::reset()
             return ;
 
     d_cavityVolume.setValue(d_initialCavityVolume.getValue());
-    d_pressure.setValue(0.0);
-    d_volumeGrowth.setValue(0.0);
 }
 
 template<class DataTypes>
@@ -208,7 +200,6 @@ void SurfacePressureModel<DataTypes>::internalInit()
                            "adding a MechanicalObject." ;
         return;
     }
-
 
     /// Check that the triangles and quads datafield contain something, otherwise get context
     /// topology
@@ -379,14 +370,19 @@ void SurfacePressureModel<DataTypes>::storeLambda(const ConstraintParams* cParam
 
     if(d_componentState.getValue() != ComponentState::Valid)
             return ;
-    
+
+    auto l = sofa::helper::getWriteAccessor(this->d_lambda);
+    auto d = sofa::helper::getWriteAccessor(this->d_delta);
+
+    l[0] = lambda->element(d_constraintIndex.getValue());
     d_pressure.setValue(lambda->element(d_constraintIndex.getValue()));
 
     // Compute actual cavity volume and volume growth from updated positions of mechanical
     // Eulalie.C: For now the position of the mechanical state is not up to date when storeLambda() is called
     //            so the value of delta is one step behind...
     //ReadAccessor<Data<VecCoord>> positions = m_state->readPositions();
-    //d_cavityVolume.setValue(getCavityVolume(positions.ref()));
+    //d[0] = getCavityVolume(positions.ref());
+    d[0] = d_cavityVolume.getValue()-d_initialCavityVolume.getValue();
     d_volumeGrowth.setValue(d_cavityVolume.getValue()-d_initialCavityVolume.getValue());
 }
 
@@ -401,7 +397,7 @@ void SurfacePressureModel<DataTypes>::draw(const VisualParams* vparams)
 
     float red, green, blue;
 
-    if (d_pressure.getValue() > 0)
+    if (this->d_lambda.getValue()[0] > 0)
     {
         red = 1.0;
         green = 0;
@@ -423,7 +419,7 @@ template<class DataTypes>
 void SurfacePressureModel<DataTypes>::drawValue(const sofa::core::visual::VisualParams* vparams)
 {
     float scale = (float)( ( vparams->sceneBBox().maxBBox() - vparams->sceneBBox().minBBox() ).norm() * d_drawScale.getValue() );
-    string value = getValueString(d_pressure.getValue());
+    string value = getValueString(this->d_lambda.getValue()[0]);
     vparams->drawTool()->draw3DText(vparams->sceneBBox().maxBBox(),scale,RGBAColor(1.,1.,1.,1.),value.c_str());
 }
 


### PR DESCRIPTION
In this PR, for the constraints:
- add binding, getter and setter to `SoftRobotsBaseConstraint`
- refactoring:
    - `d_delta` and `d_lambda` in `SoftRobotsBaseConstraint` instead of redefining them in each constraint (set to deprecated). Also added a method to rename the data if needed (e.g. pressure instead of force). 
    - add to `SoftRobotsBaseConstraint`  a method to resize the constraint vectors (default size is 1)
    - `d_delta` and `d_lambda` are `readOnly` and in group `Output`
- change some components description    